### PR TITLE
Split ACME certificate resolvers based on environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,15 @@ HTTP reverse proxy and load balancer.
 
 Copy `.env-dist` to `.env` and edit the following:
 
- * `ACME_CA_SERVER` this is the Let's Encrypt API (ACME) server to use. 
- 
-   * For development/staging use
-     `https://acme-staging-v02.api.letsencrypt.org/directory`
-   * For production use `https://acme-v02.api.letsencrypt.org/directory`
-   
  * `ACME_CA_EMAIL` this is YOUR email address, where you will receive notices
    from Let's Encrypt regarding your domains and related certificates.
 
 To start Traefik, go into the traefik directory and run `docker-compose up -d`
+
+All other services defines the `ACME_CERT_RESOLVER` variable in their respective
+`.env` file. There are two different environments defined, `staging` (default)
+and `production`. Staging will create untrusted TLS certificates for testing
+environments. Production will generate browser trustable TLS certificates.
 
 ## Gitea
 

--- a/baikal/.env-dist
+++ b/baikal/.env-dist
@@ -1,1 +1,3 @@
 BAIKAL_TRAEFIK_HOST=cal.example.com
+# Choose Let's Encrypt 'staging' or 'production' environment:
+ACME_CERT_RESOLVER=staging

--- a/baikal/docker-compose.yaml
+++ b/baikal/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.baikal.rule=Host(`${BAIKAL_TRAEFIK_HOST}`)"
       - "traefik.http.routers.baikal.entrypoints=websecure"
-      - "traefik.http.routers.baikal.tls.certresolver=default"
+      - "traefik.http.routers.baikal.tls.certresolver=${ACME_CERT_RESOLVER}"
     volumes:
       - baikal_config:/var/www/baikal/config
       - baikal_data:/var/www/baikal/Specific

--- a/cryptpad/.env-dist
+++ b/cryptpad/.env-dist
@@ -4,3 +4,5 @@
 # access information which the main domain willingly shares.
 CPAD_MAIN_DOMAIN=pad.example.com
 CPAD_SANDBOX_DOMAIN=pad.box.example.com
+# Choose Let's Encrypt 'staging' or 'production' environment:
+ACME_CERT_RESOLVER=staging

--- a/cryptpad/docker-compose.yml
+++ b/cryptpad/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - traefik.http.routers.cpad-https.entrypoints=websecure
       - traefik.http.routers.cpad-https.rule=Host(`${CPAD_MAIN_DOMAIN}`, `${CPAD_SANDBOX_DOMAIN}`)
       - traefik.http.routers.cpad-https.tls=true
-      - traefik.http.routers.cpad-https.tls.certresolver=default
+      - traefik.http.routers.cpad-https.tls.certresolver=${ACME_CERT_RESOLVER}
       - traefik.http.routers.cpad-https.service=cpad
       # Rewrite CORS headers - For some reason cryptpad is duplicating the CORS headers
       # This makes chromium browsers not load, so this rewrite rule de-duplicates the headers

--- a/gitea/.env-dist
+++ b/gitea/.env-dist
@@ -1,2 +1,4 @@
 GITEA_TRAEFIK_HOST=git.example.com
 GITEA_SSH_PORT=2222
+# Choose Let's Encrypt 'staging' or 'production' environment:
+ACME_CERT_RESOLVER=staging

--- a/gitea/docker-compose.yaml
+++ b/gitea/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
       - "traefik.http.routers.gitea-web.rule=Host(`${GITEA_TRAEFIK_HOST}`)"
       - "traefik.http.routers.gitea-web.entrypoints=websecure"
       - "traefik.http.routers.gitea-web.service=gitea-web"
-      - "traefik.http.routers.gitea-web.tls.certresolver=default"
+      - "traefik.http.routers.gitea-web.tls.certresolver=${ACME_CERT_RESOLVER}"
       - "traefik.http.services.gitea-web.loadbalancer.server.port=3000"
       ## SSH
       - "traefik.tcp.routers.gitea-ssh.rule=HostSNI(`*`)"

--- a/mosquitto/.env-dist
+++ b/mosquitto/.env-dist
@@ -1,1 +1,3 @@
 MOSQUITTO_TRAEFIK_HOST=mqtt.example.com
+# Choose Let's Encrypt 'staging' or 'production' environment:
+ACME_CERT_RESOLVER=staging

--- a/mosquitto/docker-compose.yaml
+++ b/mosquitto/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       - "traefik.tcp.routers.mqtt.rule=HostSNI(`${MOSQUITTO_TRAEFIK_HOST}`)"
       - "traefik.tcp.routers.mqtt.entrypoints=mqtt"
       - "traefik.tcp.routers.mqtt.tls=true"
-      - "traefik.tcp.routers.mqtt.tls.certresolver=default"
+      - "traefik.tcp.routers.mqtt.tls.certresolver=${ACME_CERT_RESOLVER}"
       - "traefik.tcp.routers.mqtt.service=mqtt"
       - "traefik.tcp.services.mqtt.loadBalancer.server.port=1883"
     volumes:

--- a/nextcloud/.env-dist
+++ b/nextcloud/.env-dist
@@ -12,3 +12,5 @@ OBJECTSTORE_S3_SECRET=your_s3_secret
 OBJECTSTORE_S3_REGION=your_s3_region
 OBJECTSTORE_S3_HOST=your_s3_host
 OBJECTSTORE_S3_PORT=443
+# Choose Let's Encrypt 'staging' or 'production' environment:
+ACME_CERT_RESOLVER=staging

--- a/nextcloud/docker-compose.yml
+++ b/nextcloud/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.nextcloud.rule=Host(`${NEXTCLOUD_TRAEFIK_HOST}`)"
       - "traefik.http.routers.nextcloud.entrypoints=websecure"
-      - "traefik.http.routers.nextcloud.tls.certresolver=default"
+      - "traefik.http.routers.nextcloud.tls.certresolver=${ACME_CERT_RESOLVER}"
       # the following were intended to allow dav discovery in nextcloud, but didn't work
       #- "traefik.frontend.redirect.permanent='true'"
       #- "traefik.frontend.redirect.regex='https://(.*)/.well-known/(card|cal)dav'"

--- a/nodered/.env-dist
+++ b/nodered/.env-dist
@@ -1,2 +1,4 @@
 NODERED_TRAEFIK_HOST=nodered.example.com
 NODERED_HTTP_AUTH=admin:XXXXXXX_replace_with_real_htpasswd_hash
+# Choose Let's Encrypt 'staging' or 'production' environment:
+ACME_CERT_RESOLVER=staging

--- a/nodered/docker-compose.yaml
+++ b/nodered/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       - "traefik.port=1880"
       - "traefik.http.routers.node-red.rule=Host(`${NODERED_TRAEFIK_HOST}`)"
       - "traefik.http.routers.node-red.entrypoints=websecure"
-      - "traefik.http.routers.node-red.tls.certresolver=default"
+      - "traefik.http.routers.node-red.tls.certresolver=${ACME_CERT_RESOLVER}"
       ## Authentication:
       - "traefik.http.middlewares.nodered-auth.basicauth.users=${NODERED_HTTP_AUTH}"
       - "traefik.http.routers.node-red.middlewares=nodered-auth@docker"

--- a/piwigo/.env-dist
+++ b/piwigo/.env-dist
@@ -4,3 +4,5 @@ MARIADB_DATABASE=piwigo
 MARIADB_USER=piwigo
 MARIADB_PASSWORD=changeme
 TIMEZONE=America/New_York
+# Choose Let's Encrypt 'staging' or 'production' environment:
+ACME_CERT_RESOLVER=staging

--- a/piwigo/docker-compose.yaml
+++ b/piwigo/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.piwigo.rule=Host(`${PIWIGO_TRAEFIK_HOST}`)"
       - "traefik.http.routers.piwigo.entrypoints=websecure"
-      - "traefik.http.routers.piwigo.tls.certresolver=default"
+      - "traefik.http.routers.piwigo.tls.certresolver=${ACME_CERT_RESOLVER}"
 
 volumes:
   config:

--- a/shaarli/.env-dist
+++ b/shaarli/.env-dist
@@ -1,2 +1,4 @@
 SHAARLI_TRAEFIK_HOST=shaarli.example.com
 SHAARLI_DOCKER_TAG=latest
+# Choose Let's Encrypt 'staging' or 'production' environment:
+ACME_CERT_RESOLVER=staging

--- a/shaarli/docker-compose.yml
+++ b/shaarli/docker-compose.yml
@@ -33,4 +33,4 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.shaarli.rule=Host(`${SHAARLI_TRAEFIK_HOST}`)"
       - "traefik.http.routers.shaarli.entrypoints=websecure"
-      - "traefik.http.routers.shaarli.tls.certresolver=default"
+      - "traefik.http.routers.shaarli.tls.certresolver=${ACME_CERT_RESOLVER}"

--- a/traefik-forward-auth/.env-dist
+++ b/traefik-forward-auth/.env-dist
@@ -4,3 +4,5 @@ GITEA_OAUTH_CLIENT_SECRET=change_me
 TRAEFIK_FORWARD_AUTH_SECRET=change_me
 TRAEFIK_FORWARD_AUTH_COOKIE_DOMAIN=example.com
 TRAEFIK_FORWARD_AUTH_HOST=auth.example.com
+# Choose Let's Encrypt 'staging' or 'production' environment:
+ACME_CERT_RESOLVER=staging

--- a/traefik-forward-auth/docker-compose.yaml
+++ b/traefik-forward-auth/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.traefik-forward-auth.rule=Host(`${TRAEFIK_FORWARD_AUTH_HOST}`)"
       - "traefik.http.routers.traefik-forward-auth.entrypoints=websecure"
-      - "traefik.http.routers.traefik-forward-auth.tls.certresolver=default"
+      - "traefik.http.routers.traefik-forward-auth.tls.certresolver=${ACME_CERT_RESOLVER}"
       - "traefik.http.services.traefik-forward-auth.loadbalancer.server.port=4181"
       - "traefik.http.middlewares.traefik-forward-auth.forwardAuth.address=http://traefik-forward-auth:4181"
       - "traefik.http.middlewares.traefik-forward-auth.forwardAuth.authResponseHeaders=X-Forwarded-User"

--- a/traefik/.env-dist
+++ b/traefik/.env-dist
@@ -1,2 +1,3 @@
-ACME_CA_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory
+ACME_CA_STAGING_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory
+ACME_CA_PRODUCTION_SERVER=https://acme-v02.api.letsencrypt.org/directory
 ACME_CA_EMAIL=you@example.com

--- a/traefik/docker-compose.yaml
+++ b/traefik/docker-compose.yaml
@@ -30,10 +30,14 @@ services:
     ## Automatically redirect HTTP to HTTPS
     - "--entrypoints.web.http.redirections.entryPoint.to=websecure"
     ## ACME TLS (Let's Encrypt):
-    - "--certificatesresolvers.default.acme.tlschallenge=true"
-    - "--certificatesresolvers.default.acme.caserver=${ACME_CA_SERVER}"
-    - "--certificatesresolvers.default.acme.email=${ACME_CA_EMAIL}"
-    - "--certificatesresolvers.default.acme.storage=/data/acme.json"
+    - "--certificatesresolvers.production.acme.tlschallenge=true"
+    - "--certificatesresolvers.staging.acme.tlschallenge=true"
+    - "--certificatesresolvers.production.acme.caserver=https://acme-v02.api.letsencrypt.org/directory"
+    - "--certificatesresolvers.staging.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
+    - "--certificatesresolvers.production.acme.email=${ACME_CA_EMAIL}"
+    - "--certificatesresolvers.staging.acme.email=${ACME_CA_EMAIL}"
+    - "--certificatesresolvers.production.acme.storage=/data/acme-production.json"
+    - "--certificatesresolvers.staging.acme.storage=/data/acme-staging.json"
     ## Enable Dashboard available only from the docker localhost:8080
     - "--api.dashboard=true"
     - "--api.insecure=true"

--- a/ttrss/.env-dist
+++ b/ttrss/.env-dist
@@ -27,3 +27,6 @@ TTRSS_TRAEFIK_HOST=tt-rss.example.com
 # use next HTTP_PORT definition (or remove "127.0.0.1:").
 #HTTP_PORT=127.0.0.1:8280
 #HTTP_PORT=8280
+
+# Choose Let's Encrypt 'staging' or 'production' environment:
+ACME_CERT_RESOLVER=staging

--- a/ttrss/docker-compose.yml
+++ b/ttrss/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.ttrss.rule=Host(`${TTRSS_TRAEFIK_HOST}`)"
       - "traefik.http.routers.ttrss.entrypoints=websecure"
-      - "traefik.http.routers.ttrss.tls.certresolver=default"
+      - "traefik.http.routers.ttrss.tls.certresolver=${ACME_CERT_RESOLVER}"
 
 volumes:
   db:

--- a/whoami/.env-dist
+++ b/whoami/.env-dist
@@ -1,1 +1,3 @@
 WHOAMI_TRAEFIK_HOST=whoami.example.com
+# Choose Let's Encrypt 'staging' or 'production' environment:
+ACME_CERT_RESOLVER=staging

--- a/whoami/docker-compose.yaml
+++ b/whoami/docker-compose.yaml
@@ -15,5 +15,5 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.whoami.rule=Host(`${WHOAMI_TRAEFIK_HOST}`)"
       - "traefik.http.routers.whoami.entrypoints=websecure"
-      - "traefik.http.routers.whoami.tls.certresolver=default"
+      - "traefik.http.routers.whoami.tls.certresolver=${ACME_CERT_RESOLVER}"
       # - "traefik.http.routers.whoami.middlewares=traefik-forward-auth@docker"

--- a/xbs/.env-dist
+++ b/xbs/.env-dist
@@ -3,3 +3,5 @@ DB_NAME=xbrowsersync
 DB_PASSWORD=xbsdbpass
 DB_USERNAME=xbsdb
 COMPOSE_CONVERT_WINDOWS_PATHS=1
+# Choose Let's Encrypt 'staging' or 'production' environment:
+ACME_CERT_RESOLVER=staging

--- a/xbs/docker-compose.yml
+++ b/xbs/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.xbs.rule=Host(`${XBS_TRAEFIK_HOST}`)"
       - "traefik.http.routers.xbs.entrypoints=websecure"
-      - "traefik.http.routers.xbs.tls.certresolver=default"
+      - "traefik.http.routers.xbs.tls.certresolver=${ACME_CERT_RESOLVER}"
       - "traefik.http.services.xbs.loadbalancer.server.port=8080"
 
 volumes:


### PR DESCRIPTION
The Traefik config only has one certificate resolver right now: `default`, and you choose between Let's Encrypt staging or production environments by setting the `ACME_CA_SERVER` variable in `traefik/.env`. This is a global setting and affects all deployments.

This PR splits ACME into two files. It removes the `default` certresolver and creates two new ones: `staging` and `production`, and so each deployment can choose which environment they would like their certificate created in. Traefik will store TWO acme.json files:

 * For production: `/data/acme-production.json` 
 * For development/staging: `/data/acme-staging.json`

If you redeploy Traefik, in the `traefik` directory, with `docker-compose up -d`, all of your existing deployments will now have invalid certificates. You can check the traefik logs to see why:

```
time="2021-07-25T21:40:37Z" level=error msg="the router whoami@docker uses a non-existent resolver: default"
time="2021-07-25T21:40:37Z" level=error msg="the router piwigo@docker uses a non-existent resolver: default"
```

(On this server I only have deployments for `whoami` and `piwigo`.)

This is because all of the existing deployments use the `default` certificate resolver, which has now been removed. You need to add the `ACME_CERT_RESOLVER` variable to all of your deployment `.env` files and choose `staging` or `production` depending on whether you need a production certificate or not, and redeploy (If you do not add the variable, the service will have an invalid `TRAEFIK DEFAULT CERT` certificate.)

All of the example `.env-dist` files now have added a `ACME_CERT_RESOLVER` variable with the default for the `staging` environment. You need to copy these to any existing `.env` files.

If you want to retain all of your old production certificates, you will need to copy your old `acme.json` to the new `acme-production.json` file:

Enter into the shell of the container running Traefik:

```
docker exec -it traefik /bin/sh
```

Now inside the traefik container, run:

```
awk '/default/ && !done { gsub(/default/, "production"); done=1}; 1' /data/acme.json > /data/acme-production.json
chmod 600 /data/acme-production.json
```

(This will copy acme.json to acme-production.json and automatically edit the name inside from "default" to "production".)

Press `Ctrl-D` to exit the container.

Restart traefik again. In the `traefik` directory run `docker-compose up -d`.

