### PR TITLE
Autoheal

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ Install these first:
 Install these services at your leisure/preference:
 
 * [ArchiveBox](archivebox) - a website archiving tool
+* [Autoheal](autoheal) - a Docker container healthcheck monitor with auto-restart service
 * [Baikal](baikal) - a lightweight CalDAV+CardDAV server
 * [Bitwarden](bitwarden_rs) - a password manager
 * [CryptPad](cryptpad) - a collaborative document and spreadsheet editor 

--- a/_scripts/Makefile.lifecycle
+++ b/_scripts/Makefile.lifecycle
@@ -36,7 +36,7 @@ ps:
 
 .PHONY: status # Show status of all instances
 status:
-	@(echo -e "NAME\tENV\tID\tIMAGE\tSTATE\tPORTS" && docker ps --filter "label=com.docker.compose.project.working_dir=$${PWD}" -q | xargs -iXX docker inspect XX | jq '.[0]' | jq -r '(.Name[1:]) + "\t" + (.Config.Labels["com.docker.compose.project.environment_file"] | split("/";"")[-1]) + "\t" + .Id[:10] + "\t" + .Config.Image + "\t" + .State.Status + "\t" + (.NetworkSettings.Ports|tostring) ') | column -t
+	@(echo -e "NAME\tENV\tID\tIMAGE\tSTATE\tHEALTH\tPORTS" && docker ps --filter "label=com.docker.compose.project.working_dir=$${PWD}" -q | xargs -iXX docker inspect XX | jq '.[0]' | jq -r '(.Name[1:]) + "\t" + (.Config.Labels["com.docker.compose.project.environment_file"] | split("/";"")[-1]) + "\t" + .Id[:10] + "\t" + .Config.Image + "\t" + .State.Status + "\t" + (.State.Health.Status|tostring) + "\t" + (.NetworkSettings.Ports|tostring) ') | column -t
 
 .PHONY: logs # Tail all containers logs (set SERVICE=name to filter for one)
 logs:

--- a/autoheal/.env-dist
+++ b/autoheal/.env-dist
@@ -1,0 +1,22 @@
+## https://github.com/willfarrell/docker-autoheal/tags
+AUTOHEAL_VERSION=1.2.0
+
+# The label to enable certain containers to be autohealed.
+# Use `all` to monitor all containers regardless of any labels.
+AUTOHEAL_CONTAINER_LABEL=autoheal
+
+# check every X seconds
+AUTOHEAL_INTERVAL=5
+
+# wait 0 seconds before first health check
+AUTOHEAL_START_PERIOD=0
+
+# Docker waits max 10 seconds (the Docker default) for a container to stop before killing during restarts
+## override by setting a container label: `autoheal.stop.timeout=20`
+AUTOHEAL_DEFAULT_STOP_TIMEOUT=10
+
+# --max-time seconds for curl requests to Docker API
+AUTOHEAL_CURL_TIMEOUT=30
+
+# post message to the webhook if a container was restarted (or restart failed)
+AUTOHEAL_WEBHOOK_URL=

--- a/autoheal/Makefile
+++ b/autoheal/Makefile
@@ -1,0 +1,9 @@
+ROOT_DIR = ..
+include ${ROOT_DIR}/_scripts/Makefile.projects
+include ${ROOT_DIR}/_scripts/Makefile.instance
+
+.PHONY: config-hook
+config-hook:
+	@${BIN}/confirm $$(test "$$(${BIN}/dotenv -f ${ENV_FILE} get AUTOHEAL_CONTAINER_LABEL)" == "all" && echo "yes" || echo "no") "Do you want autoheal to monitor/restart ALL unhealthy containers (no label required)" "?" && ${BIN}/reconfigure ${ENV_FILE} AUTOHEAL_CONTAINER_LABEL=all || ${BIN}/reconfigure_ask ${ENV_FILE} AUTOHEAL_CONTAINER_LABEL "Enter the docker label name for enabling autoheal (eg. \`autoheal\` will watch all containers with the label \`autoheal=true\`)" "autoheal"
+	@${BIN}/reconfigure_ask ${ENV_FILE} AUTOHEAL_INTERVAL "Enter how often (in seconds) do you want to check for unhealthy containers" 5
+

--- a/autoheal/README.md
+++ b/autoheal/README.md
@@ -1,0 +1,54 @@
+# Autoheal
+
+[Docker Autoheal](https://github.com/willfarrell/docker-autoheal) is a
+Docker
+[`HEALTHCHECK`](https://docs.docker.com/engine/reference/builder/#healthcheck)
+monitor. Whereas Docker will already run the specified healthchecks
+and mark containers that fail them as `unhealthy`, it does not take
+any action upon that check. It would be nice if Docker would
+(optionally) restart unhealthy services automatically. While Docker
+Swarm has this functionality builtin, it is not enabled for normal
+non-swarm Docker daemons. Docker Autoheal is a separate service that
+fixes this missing functionality. This service binds to the Docker
+socket, and so it receives health notices for all containers, and can
+automatically restart those that are unhealthy, based upon
+configuration applied in those container's Docker labels.
+
+## Setup
+
+```
+make config
+```
+
+You must configure autoheal to tell it which of your containers it should watch:
+
+ * Set `AUTOHEAL_CONTAINER_LABEL=all` to watch ALL containers
+   indiscriminantly (but only for containers that actually have a
+   `HEALTHCHECK`).
+ * Otherwise set this to a specific label name, eg.
+   `AUTOHEAL_CONTAINER_LABEL=autoheal`, and then only the containers
+   with the label `autoheal=true` will be watched (set this label on
+   any other container on your Docker host.).
+
+## Install
+
+```
+make install
+```
+
+## Read the logs
+
+The logs are very quiet: nothing is printed on startup unless there is
+an error. When a watched container becomes unhealthy, and if it is
+configured to be restarted, you will see a message like this when it
+is restarted:
+
+```
+autoheal-autoheal-1  | 21-02-2023 21:50:42 Container /unhealthy-example (3cd71f557bc7) found to be unhealthy - Restarting container now with 10s timeout
+```
+
+## Example HEALTHCHECK
+
+An [example service](example) is included for how to create a
+healthcheck and to test inducing an unhealthy state, and having
+autoheal restart it.

--- a/autoheal/docker-compose.yaml
+++ b/autoheal/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: "3.9"
+
+services:
+  autoheal:
+    build:
+      context: https://github.com/willfarrell/docker-autoheal.git#${AUTOHEAL_VERSION}
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    restart: unless-stopped
+    environment:
+      - AUTOHEAL_CONTAINER_LABEL
+      - AUTOHEAL_INTERVAL
+      - AUTOHEAL_START_PERIOD
+      - AUTOHEAL_DEFAULT_STOP_TIMEOUT
+      - CURL_TIMEOUT=${AUTOHEAL_CURL_TIMEOUT}
+      - WEBHOOK_URL=${AUTOHEAL_WEBHOOK_URL}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/autoheal/example/.env-dist
+++ b/autoheal/example/.env-dist
@@ -1,0 +1,2 @@
+## Set TIMEOUT to a value > 30 to induce an unhealthy state
+TIMEOUT=5

--- a/autoheal/example/Dockerfile
+++ b/autoheal/example/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:latest
+ENV TIMEOUT=5
+CMD echo 'Sleeping forever ...' && while true; do sleep 1; done
+HEALTHCHECK --interval=30s --timeout=30s --start-period=1ms --retries=3 \
+    CMD sleep ${TIMEOUT}

--- a/autoheal/example/Makefile
+++ b/autoheal/example/Makefile
@@ -1,0 +1,6 @@
+ROOT_DIR = ../..
+include ${ROOT_DIR}/_scripts/Makefile.projects
+
+.PHONY: config-hook
+config-hook:
+	@${BIN}/reconfigure_ask ${ENV_FILE} TIMEOUT "Set the timeout in seconds. (If < 30, service will be healthy, otherwise unhealthy)" 60

--- a/autoheal/example/README.md
+++ b/autoheal/example/README.md
@@ -1,0 +1,35 @@
+# Example for unhealthy HEALTHCHECK
+
+This service is a simple example that shows a Docker
+[`HEALTHCHECK`](https://docs.docker.com/engine/reference/builder/#healthcheck)
+and a test for inducing an unhealthy state.
+
+```
+make config
+```
+
+choose the value for `TIMEOUT` in seconds. If you set this to a value
+less than 30, the service will be considered healthy, otherwise
+unhealthy.
+```
+make install
+```
+
+With the example service now running, watch the status:
+
+```
+watch make status
+```
+
+Check the output of the status for the current health. It should
+initially say `starting` until the healthcheck either succeeds or
+fails. The healthcheck requires the timeout to occur up to three
+times, with 30s in between checks; so after ~2mins it should change to
+either `healthy` or `unhealthy`.
+
+The service has the label `autoheal=true`, so if you are running the
+[autoheal](../README.md) service, the unhealthy service should be
+automatically restarted (otherwise the service will run forever in the
+unhealthy state).
+
+

--- a/autoheal/example/docker-compose.yaml
+++ b/autoheal/example/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: "3.9"
+
+services:
+  unhealthy-example:
+    container_name: unhealthy-example
+    build:
+      context: .
+    restart: unless-stopped
+    environment:
+      - TIMEOUT
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    labels:
+      - autoheal=true


### PR DESCRIPTION
[Docker Autoheal](https://github.com/willfarrell/docker-autoheal) is a Docker [`HEALTHCHECK`](https://docs.docker.com/engine/reference/builder/#healthcheck) monitor and auto-restart service.