### PR TITLE
Docker socket

### DIFF
--- a/traefik/Makefile
+++ b/traefik/Makefile
@@ -11,7 +11,7 @@ config-hook: traefik-user config-ask compose-profiles
 
 .PHONY: traefik-user
 traefik-user:
-	@SSH_HOST=$$(docker context inspect | jq -r ".[0].Endpoints.docker.Host"); SSH_UID=$$(ssh $${SSH_HOST} id -u); [[ $SSH_UID != "0" ]] && SUDO_PREFIX="sudo" || SUDO_PREFIX=""; (ssh $${SSH_HOST} id traefik && echo "Traefik user exists.") || (ssh $${SSH_HOST} $${SUDO_PREFIX} adduser --disabled-login --disabled-password --gecos GECOS traefik && ssh $${SSH_HOST} $${SUDO_PREFIX} gpasswd -a traefik docker)
+	@SSH_HOST=$$(docker context inspect | jq -r ".[0].Endpoints.docker.Host"); if [[ "$${SSH_HOST}" == unix://* ]]; then echo "Not creating the traefik-user because there is no SSH context" ; else (SSH_UID=$$(ssh $${SSH_HOST} id -u); [[ $SSH_UID != "0" ]] && SUDO_PREFIX="sudo" || SUDO_PREFIX=""; (ssh $${SSH_HOST} id traefik && echo "Traefik user exists.") || (ssh $${SSH_HOST} $${SUDO_PREFIX} adduser --disabled-login --disabled-password --gecos GECOS traefik && ssh $${SSH_HOST} $${SUDO_PREFIX} gpasswd -a traefik docker)); fi;
 
 .PHONY: config-ask
 config-ask:
@@ -26,9 +26,9 @@ config-ask:
 	@echo ""
 	@[[ $$(${BIN}/dotenv -f ${ENV_FILE} get TRAEFIK_VPN_ENABLED) != "true" ]] && ${BIN}/confirm $$([[ $$(${BIN}/dotenv -f ${ENV_FILE} get TRAEFIK_VPN_CLIENT_ENABLED) == "true" ]] && echo "yes" || echo "no") "Do you want to run Traefik as a reverse proxy for an external VPN (wireguard client mode)" "?" && make --no-print-directory config-wireguard-client || ${BIN}/reconfigure ${ENV_FILE} TRAEFIK_VPN_CLIENT_ENABLED=false || true
 	@[[ $$(${BIN}/dotenv -f ${ENV_FILE} get TRAEFIK_VPN_ENABLED) != "true" ]] && [[ $$(${BIN}/dotenv -f ${ENV_FILE} get TRAEFIK_VPN_CLIENT_ENABLED) != "true" ]] && ${BIN}/reconfigure ${ENV_FILE} TRAEFIK_NETWORK_MODE=host TRAEFIK_DASHBOARD_ENTRYPOINT_HOST=127.0.0.1 || true
-	@TRAEFIK_UID=$$(ssh $$(docker context inspect | jq -r ".[0].Endpoints.docker.Host") id -u traefik) && ${BIN}/dotenv -f ${ENV_FILE} set TRAEFIK_UID=$${TRAEFIK_UID} && echo "Set TRAEFIK_UID=$${TRAEFIK_UID}"
-	@TRAEFIK_GID=$$(ssh $$(docker context inspect | jq -r ".[0].Endpoints.docker.Host") id -g traefik) && ${BIN}/dotenv -f ${ENV_FILE} set TRAEFIK_GID=$${TRAEFIK_GID} && echo "Set TRAEFIK_GID=$${TRAEFIK_GID}"
-	@TRAEFIK_DOCKER_GID=$$(ssh $$(docker context inspect | jq -r ".[0].Endpoints.docker.Host") getent group docker | cut -d: -f3) && ${BIN}/dotenv -f ${ENV_FILE} set TRAEFIK_DOCKER_GID=$${TRAEFIK_DOCKER_GID} && echo "Set TRAEFIK_DOCKER_GID=$${TRAEFIK_DOCKER_GID}"
+	@SSH_HOST=$$(docker context inspect | jq -r ".[0].Endpoints.docker.Host"); if [[ "$${SSH_HOST}" == unix://* ]]; then ${BIN}/reconfigure ${ENV_FILE} TRAEFIK_UID=1000 ; else (TRAEFIK_UID=$$(ssh $${SSH_HOST} id -u traefik) && ${BIN}/dotenv -f ${ENV_FILE} set TRAEFIK_UID=$${TRAEFIK_UID} && echo "Set TRAEFIK_UID=$${TRAEFIK_UID}"); fi
+	@SSH_HOST=$$(docker context inspect | jq -r ".[0].Endpoints.docker.Host"); if [[ "$${SSH_HOST}" == unix://* ]]; then ${BIN}/reconfigure ${ENV_FILE} TRAEFIK_GID=1000 ; else (TRAEFIK_GID=$$(ssh $${SSH_HOST} id -g traefik) && ${BIN}/dotenv -f ${ENV_FILE} set TRAEFIK_GID=$${TRAEFIK_GID} && echo "Set TRAEFIK_GID=$${TRAEFIK_GID}"); fi
+	@SSH_HOST=$$(docker context inspect | jq -r ".[0].Endpoints.docker.Host"); if [[ "$${SSH_HOST}" == unix://* ]]; then ${BIN}/reconfigure ${ENV_FILE} TRAEFIK_DOCKER_GID=$$(getent group docker | cut -d ':' -f 3); else (TRAEFIK_DOCKER_GID=$$(ssh $$(docker context inspect | jq -r ".[0].Endpoints.docker.Host") getent group docker | cut -d: -f3) && ${BIN}/dotenv -f ${ENV_FILE} set TRAEFIK_DOCKER_GID=$${TRAEFIK_DOCKER_GID} && echo "Set TRAEFIK_DOCKER_GID=$${TRAEFIK_DOCKER_GID}"); fi
 
 .PHONY: config-wireguard
 config-wireguard:


### PR DESCRIPTION
This branch enables using Docker via the unix socket /var/run/docker.sock instead of the default SSH context.

Fixes #72 

Things that are still broken:
 * traefik `make open` needs SSH still
 * traefik cannot use host networking on Docker Desktop.