### PR TITLE
docker image source changed, also updated default version

### DIFF
--- a/homepage/.env-dist
+++ b/homepage/.env-dist
@@ -2,7 +2,7 @@
 HOMEPAGE_TRAEFIK_HOST=homepage.example.com
 
 # The tag for the Docker image
-HOMEPAGE_VERSION=v0.6.27
+HOMEPAGE_VERSION=v0.7.3
 
 # The name of this instance. If there is only one instance, use 'default'.
 HOMEPAGE_INSTANCE=

--- a/homepage/homepage/Dockerfile
+++ b/homepage/homepage/Dockerfile
@@ -1,5 +1,5 @@
 ARG HOMEPAGE_VERSION
-FROM ghcr.io/benphelps/homepage:${HOMEPAGE_VERSION}
+FROM ghcr.io/gethomepage/homepage:${HOMEPAGE_VERSION}
 RUN apk add --no-cache bash openssh git envsubst grep rsync
 WORKDIR /app
 ADD . /app/reloader


### PR DESCRIPTION
There are newer versions of Homepage (one potentially nice feature is tabs), and the image source changed from `ghcr.io/benphelps/homepage` to `ghcr.io/gethomepage/homepage`.