### PR TITLE
Install script-wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docker-compose.override*.yaml
 dump.*
 tasks.org
 node_modules
+_scripts/script-wizard

--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,24 @@ help:
 include _scripts/Makefile.globals
 include _scripts/Makefile.cd
 
+.PHONY: install-script-wizard
+install-script-wizard:
+	_scripts/install_script-wizard
+
+.PHONY: script-wizard
+script-wizard:
+	@test -f _scripts/script-wizard && (echo "Found script-wizard: $$(_scripts/script-wizard --version) (${ROOT_DIR}/_scripts/script-wizard)" || _scripts/install_script-wizard)
+
 .PHONY: check-deps
 check-deps:
-	_scripts/check_deps docker sed awk xargs openssl htpasswd jq
+	_scripts/check_deps docker sed awk xargs openssl htpasswd jq curl
 
 .PHONY: check-docker
 check-docker:
 	@docker info >/dev/null && echo "Docker is running." || (echo "Could not connect to Docker!" && false)
 
 .PHONY: config # Configure main variables
-config: check-deps check-docker
+config: script-wizard check-deps check-docker
 #	@${BIN}/userns-remap check
 	@echo ""
 	@${BIN}/confirm yes "This will make a configuration for the current docker context (${DOCKER_CONTEXT})"
@@ -119,4 +127,3 @@ docker-workstation:
 docker-workstation-clean:
 	docker compose -f compose-dev.yaml kill
 	docker compose -f compose-dev.yaml down -v
-  

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install-script-wizard:
 
 .PHONY: script-wizard
 script-wizard:
-	@test -f _scripts/script-wizard && (echo "Found script-wizard: $$(_scripts/script-wizard --version) (${ROOT_DIR}/_scripts/script-wizard)" || _scripts/install_script-wizard)
+	@test -f _scripts/script-wizard && echo "Found script-wizard: $$(_scripts/script-wizard --version) (${ROOT_DIR}/_scripts/script-wizard)" || _scripts/install_script-wizard
 
 .PHONY: check-deps
 check-deps:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ all of the dependent files are fully contained by Docker itself
 state is managed as part of the container/volume lifecycle.
 
 ## Prerequisites
-### Create a Docker host
+### Create a Docker host (server)
 
 [Install Docker
 Server](https://docs.docker.com/engine/install/#server) on your own
@@ -215,7 +215,21 @@ find traefik and the wireguard server/client in this latter category).
 Each sub-project directory also has a `make status` with useful
 per-project information.
 
-## Setup
+## Setup Workstation
+
+Your local "workstation" is assumed to be a Linux desktop/laptop
+computer, or another Linux system that you remotely connect to via
+SSH:
+
+ * Tested workstation architectures:
+   * Linux x86_64 (64 bit Intel or AMD)
+   * Linux aarch64 (64 bit ARM)
+   * Arch Linux and Ubuntu have been regularly tested.
+ * Other operating systems and architectures have not been tested, and
+may require customization (please [open an
+issue](https://github.com/EnigmaCurry/script-wizard/issues)).
+ * Your workstation should not be the same machine as the docker
+   server (unless docker is in its own virtual machine).
 
 ### Install Docker CLI tools
 
@@ -266,14 +280,15 @@ installation:
 docker buildx install
 ```
 
-### Install workstation tools (optional)
+### Install workstation tools
 
-There are also **optional** helper scripts and Makefiles included,
-that will have some additional system package requirements (Note:
-these Makefiles are just convenience wrappers for creating/modifying
-your `.env` files and for running `docker compose`, so these are not
-required to use if you would rather just edit your `.env` files by
-hand and/or run `docker compose` manually.):
+The Makefiles have extra dependencies in order to help configure and
+manage your containers. These dependencies are optional, but strongly
+recommended. (The Makefiles are strictly convenience wrappers for
+creating/modifying your `.env` files, and for running `docker compose`
+commands, so if you would rather just edit your `.env` files by hand
+and/or run `docker compose` manually, these dependencies may be
+skipped):
 
    * Base development tools including `bash`, `make`, `sed`, `xargs`, and
      `shred`.
@@ -418,6 +433,12 @@ Run the configuration wizard, and answer the questions:
 ## Run this command inside the root source directory of d.rymcg.tech:
 make config
 ```
+
+This will check your system for the dependencies and alert you if you
+need to install something. All of the Makefiles depend on a helper
+utility called
+[script-wizard](https://github.com/enigmacurry/script-wizard), which
+is automatically installed the first time you run `make config`.
 
 (This writes the main project level variables into a file named
 `.env_${DOCKER_CONTEXT}` (eg. `.env_d.example.com`) in the root source

--- a/_scripts/confirm
+++ b/_scripts/confirm
@@ -1,21 +1,12 @@
 #!/bin/bash
 
+BIN=$(realpath $(dirname ${BASH_SOURCE}))
+source ${BIN}/funcs.sh
+
 ## Confirm with the user
 ## Check env for the var YES, if it equals "yes" then bypass this confirm
 test ${YES:-no} == "yes" && exit 0
 
 default=$1; prompt=$2; question=${3:-". Proceed?"}
-if [[ $default == "y" || $default == "yes" || $default == "ok" ]]; then
-    dflt="Y/n"
-else
-    dflt="y/N"
-fi
 
-read -p "${prompt}${question} (${dflt}): " answer
-answer=${answer:-${default}}
-
-if [[ ${answer,,} == "y" || ${answer,,} == "yes" || ${answer,,} == "ok" ]]; then
-    exit 0
-else
-    exit 1
-fi
+wizard confirm "$prompt$question" "$default"

--- a/_scripts/funcs.sh
+++ b/_scripts/funcs.sh
@@ -189,3 +189,7 @@ random_port() {
                                                        grep "[0-9]\{1,5\}" | sort | uniq) 2>/dev/null | \
         shuf 2>/dev/null | head -n 1; true
 }
+
+wizard() {
+    ${BIN}/script-wizard "$@"
+}

--- a/_scripts/funcs.sh
+++ b/_scripts/funcs.sh
@@ -31,7 +31,7 @@ check_num(){
 ask() {
     ## Ask the user a question and set the given variable name with their answer
     local __prompt="${1}"; local __var="${2}"; local __default="${3}"
-    read -e -p "${__prompt}"$'\x0a: ' -i "${__default}" ${__var}
+    read -e -p "${__prompt}"$'\x0a\e[32m:\e[0m ' -i "${__default}" ${__var}
     export ${__var}
 }
 
@@ -40,7 +40,7 @@ ask_no_blank() {
     ## If the answer is blank, repeat the question.
     local __prompt="${1}"; local __var="${2}"; local __default="${3}"
     while true; do
-        read -e -p "${__prompt}"$'\x0a: ' -i "${__default}" ${__var}
+        read -e -p "${__prompt}"$'\x0a\e[32m:\e[0m ' -i "${__default}" ${__var}
         export ${__var}
         [[ -z "${!__var}" ]] || break
     done

--- a/_scripts/install_script-wizard
+++ b/_scripts/install_script-wizard
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+BIN=$(realpath $(dirname ${BASH_SOURCE}))
+source ${BIN}/funcs.sh
+set -e
+
+echo "## Running script-wizard installer ..."
+echo "## See https://github.com/enigmacurry/script-wizard"
+${BIN}/check_deps curl jq
+
+get_latest_version() {
+    curl -sL https://api.github.com/repos/EnigmaCurry/script-wizard/releases/latest | jq -r ".tag_name"  | sed 's/^v//'
+}
+
+check_os() {
+    SUPPORTED_OS=$@
+    if ! echo "${SUPPORTED_OS[@]}" | grep -F --word-regexp "$(uname -s)" >/dev/null; then
+        echo -e "\nError: Your operating system ($(uname -s)) is not supported by script-wizard (yet)."
+        echo -e "Please file an issue at https://github.com/EnigmaCurry/script-wizard/issues\n"
+        echo "Supported operating systems: ${SUPPORTED_OS[@]}"
+        exit 1
+    else
+        echo "Found supported OS: $(uname -s)"
+    fi
+}
+
+check_os_architecture() {
+    OS=$1; shift;
+    SUPPORTED_ARCHITECTURES=$@
+    if [[ "$(uname -s)" == "${OS}" ]]; then
+        if ! echo "${SUPPORTED_ARCHITECTURES[@]}" | grep -F --word-regexp "$(uname -m)" >/dev/null; then
+            echo -e "\nError: Your system architecture ($(uname -m)) is not supported by script-wizard (yet)."
+            echo -e "Please file an issue at https://github.com/EnigmaCurry/script-wizard/issues\n"
+            echo "Supported architectures: ${SUPPORTED_ARCHITECTURES[@]}"
+            exit 1
+        fi
+        echo "Found supported architecture: $(uname -m)"
+    else
+        return 1
+    fi
+}
+
+download() {
+    SCRIPT_WIZARD_TARBALL="script-wizard-$(uname -s)-$(uname -m).tar.gz"
+    SCRIPT_WIZARD_DOWNLOAD_URL="https://github.com/Enigmacurry/script-wizard/releases/latest/download/${SCRIPT_WIZARD_TARBALL}"
+    TMP_DIR=$(mktemp -d)
+    cd ${TMP_DIR}
+    echo "## Downloading ..."
+    exe curl -LO "${SCRIPT_WIZARD_DOWNLOAD_URL}"
+    tar xfvz "${SCRIPT_WIZARD_TARBALL}"
+    mv ${TMP_DIR}/script-wizard ${BIN}
+}
+
+## Check all supported OS:
+check_os Linux
+## Check each supported architectures per OS:
+check_os_architecture Linux x86_64 aarch64
+
+LATEST_RELEASE=$(get_latest_version)
+echo "Latest released version: ${LATEST_RELEASE}"
+if test -f ${BIN}/script-wizard; then
+    echo "script-wizard is already installed: ${BIN}/script-wizard"
+    INSTALLED_VERSION=$(${BIN}/script-wizard --version | cut -d ' ' -f 2)
+    echo "script-wizard version (installed): ${INSTALLED_VERSION}"
+    if [[ "$INSTALLED_VERSION" == "$LATEST_RELEASE" ]]; then
+        echo "You already have the latest version of script-wizard installed."
+        exit 0
+    else
+        echo "Re-installing latest version ..."
+    fi
+fi
+download

--- a/_scripts/install_script-wizard
+++ b/_scripts/install_script-wizard
@@ -70,3 +70,4 @@ if test -f ${BIN}/script-wizard; then
     fi
 fi
 download
+echo "Installed new script-wizard version: $(${BIN}/script-wizard --version | cut -d ' ' -f 2) (${BIN}/script-wizard)"

--- a/_scripts/reconfigure_ask
+++ b/_scripts/reconfigure_ask
@@ -37,7 +37,7 @@ if [[ "${#example}" -ne "0" ]]; then
     example=" (eg. ${example})"
 fi
 while true; do
-    read -e -p "${var}: ${prompt}${example}"$'\x0a: ' -i "${default}" answer
+    read -e -p "${var}: ${prompt}${example}"$'\x0a\e[32m:\e[0m ' -i "${default}" answer
     if [[ -n ${answer} || -z ${default} || "${ALLOW_BLANK}" == 1 ]]; then
         break
     fi

--- a/_scripts/reconfigure_choose
+++ b/_scripts/reconfigure_choose
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## reconfigure_choose ENV_FILE VAR PROMPT CHOICE...
+## Shows the user a list of choices and edits the config file variable VAR with the selection
+
+## Example:
+## ${BIN}/reconfigure_choose .env THING "choose a THING" "Thing 1" "Thing 2" "Something else" "None of the above"
+
+ENV_FILE="$1"; shift
+var="$1"; shift
+prompt="$1"; shift
+choices=("$@")
+
+BIN=$(dirname ${BASH_SOURCE})
+source ${BIN}/funcs.sh
+
+check_var ENV_FILE var prompt choices
+
+## Make new .env if it doesn't exist:
+test -f ${ENV_FILE} || cp .env-dist ${ENV_FILE}
+
+answer=$(eval "${BIN}/script-wizard choose ${prompt@Q} ${choices[@]@Q}")
+${BIN}/reconfigure ${ENV_FILE} ${var}="${answer}"

--- a/_scripts/reconfigure_choose
+++ b/_scripts/reconfigure_choose
@@ -19,5 +19,6 @@ check_var ENV_FILE var prompt choices
 ## Make new .env if it doesn't exist:
 test -f ${ENV_FILE} || cp .env-dist ${ENV_FILE}
 
-answer=$(eval "${BIN}/script-wizard choose ${prompt@Q} ${choices[@]@Q}")
+DEFAULT=$(${BIN}/dotenv -f "${ENV_FILE}" get "${var}")
+answer=$(eval "${BIN}/script-wizard choose ${prompt@Q} ${choices[@]@Q} --default '$DEFAULT'")
 ${BIN}/reconfigure ${ENV_FILE} ${var}="${answer}"

--- a/_scripts/reconfigure_editor
+++ b/_scripts/reconfigure_editor
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+## reconfigure_editor ENV_FILE VAR PROMPT
+## Allows user to edit a variable in the .env file using a full text editor
+## Output is serialized to a JSON string.
+
+## Example:
+## ${BIN}/reconfigure_editor .env BIOGRAPHY "Tell me about yourself"
+
+ENV_FILE="$1"; shift
+var="$1"; shift
+prompt="$1"; shift
+
+BIN=$(dirname ${BASH_SOURCE})
+source ${BIN}/funcs.sh
+
+check_var ENV_FILE var prompt
+
+## Make new .env if it doesn't exist:
+test -f ${ENV_FILE} || cp .env-dist ${ENV_FILE}
+
+DEFAULT=$(${BIN}/dotenv -f "${ENV_FILE}" get "${var}")
+answer=$(eval "${BIN}/script-wizard editor ${prompt@Q} --json --default '$DEFAULT'")
+
+## Strip everything before the first double quote " of the properly
+## JSON formatted string: This fixes a bug when inquire reads the text
+## coming from emacsclient "Waiting for Emacs..." and it prepended
+## that to the output.
+answer=$(echo "${answer}" | sed 's/^[^\"]*//')
+
+## Set the final answer:
+${BIN}/reconfigure ${ENV_FILE} ${var}="${answer}"

--- a/_scripts/reconfigure_select
+++ b/_scripts/reconfigure_select
@@ -21,5 +21,5 @@ test -f ${ENV_FILE} || cp .env-dist ${ENV_FILE}
 
 DEFAULT=$(${BIN}/dotenv -f "${ENV_FILE}" get "${var}")
 
-answer=$(eval "${BIN}/script-wizard select ${prompt@Q} ${selections[@]@Q} --default '$DEFAULT'")
+answer=$(eval "${BIN}/script-wizard select --json ${prompt@Q} ${selections[@]@Q} --default '$DEFAULT'")
 ${BIN}/reconfigure ${ENV_FILE} ${var}="${answer}"

--- a/_scripts/reconfigure_select
+++ b/_scripts/reconfigure_select
@@ -19,5 +19,7 @@ check_var ENV_FILE var prompt selections
 ## Make new .env if it doesn't exist:
 test -f ${ENV_FILE} || cp .env-dist ${ENV_FILE}
 
-answer=$(eval "${BIN}/script-wizard select ${prompt@Q} ${selections[@]@Q}" | jq -cRn '[inputs]')
+DEFAULT=$(${BIN}/dotenv -f "${ENV_FILE}" get "${var}")
+
+answer=$(eval "${BIN}/script-wizard select ${prompt@Q} ${selections[@]@Q} --default '$DEFAULT'")
 ${BIN}/reconfigure ${ENV_FILE} ${var}="${answer}"

--- a/_scripts/reconfigure_select
+++ b/_scripts/reconfigure_select
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## reconfigure_select ENV_FILE VAR PROMPT CHOICE...
+## Shows the user a multiple select UI and edits the config file variable VAR with a JSON list of all the selections
+
+## Example:
+## ${BIN}/reconfigure_select .env THINGS "select many THINGS" "Thing 1" "Thing 2" "Something else"
+
+ENV_FILE="$1"; shift
+var="$1"; shift
+prompt="$1"; shift
+selections=("$@")
+
+BIN=$(dirname ${BASH_SOURCE})
+source ${BIN}/funcs.sh
+
+check_var ENV_FILE var prompt selections
+
+## Make new .env if it doesn't exist:
+test -f ${ENV_FILE} || cp .env-dist ${ENV_FILE}
+
+answer=$(eval "${BIN}/script-wizard select ${prompt@Q} ${selections[@]@Q}" | jq -cRn '[inputs]')
+${BIN}/reconfigure ${ENV_FILE} ${var}="${answer}"


### PR DESCRIPTION
This installs [script-wizard](https://github.com/enigmacurry/script-wizard) when you run the root `make config`.

script-wizard will help us make a better UI for the questions that the makefiles ask.

This PR refactors the `confirm` script to use script-wizard.

I have to think more if I want to overwrite the `ask` functions, I don't think theres much to gain by replacing them.

The main benefit of this will be the additional methods of `choose` and `select` which allow choosing from multiple choices.

So far in d.rymcg.tech we have only had binary choices in the makefiles, but now with script wizard we can make multiple choice selections.