### PR TITLE
Add common `make shell` target helper

### DIFF
--- a/_scripts/Makefile.docker-compose
+++ b/_scripts/Makefile.docker-compose
@@ -12,3 +12,6 @@ docker-compose-lifecycle-cmd: check-instance-project
 docker-compose-build: check-instance-project
 	@make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="build ${EXTRA_ARGS} ${service}"
 
+.PHONY: docker-compose-shell
+docker-compose-shell:
+	@COMMAND=$${COMMAND:-"/bin/bash || /bin/sh"}; make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -it ${SERVICE} /bin/sh -c '$${COMMAND}'"


### PR DESCRIPTION
As part of #28 we need to make a common `make shell` target supports instances and a configurable service name to shell into. This creates the `docker-compose-shell` make target.

For example:

```
.PHONY: shell
shell:
	@make --no-print-directory docker-compose-shell SERVICE=qbittorrent COMMAND=/bin/bash
```

This needs to be copied and customized to every app (!)