### PR TITLE
colorize current context in `d.rymcg.tech context`

### DIFF
--- a/_scripts/colorize
+++ b/_scripts/colorize
@@ -1,0 +1,1 @@
+run_func

--- a/_scripts/d.rymcg.tech
+++ b/_scripts/d.rymcg.tech
@@ -178,23 +178,7 @@ __info() {
 __context() {
     if [[ $# == 0 ]]; then
         # Run `docker context ls` and store the output in a variable
-        output=$(docker context ls)
-        
-        # Set the color variables
-        green=$(tput setaf 2)      # Green text color
-        reset=$(tput sgr0)        # Reset text formatting
-        
-        # Loop through each line of the output
-        while IFS= read -r line; do
-          # Check if the line contains an asterisk (*)
-          if [[ $line == *"*"* ]]; then
-            # Replace the entire line with the same text but in green
-            green_line="${green}${line}${reset}"
-            echo "$green_line"
-          else
-            echo "$line"
-          fi
-        done <<< "$output"
+        exe docker context ls | colorize "green" ' \* '
     else
         exe docker context use "$@"
     fi

--- a/_scripts/d.rymcg.tech
+++ b/_scripts/d.rymcg.tech
@@ -177,7 +177,24 @@ __info() {
 
 __context() {
     if [[ $# == 0 ]]; then
-        exe docker context ls
+        # Run `docker context ls` and store the output in a variable
+        output=$(docker context ls)
+        
+        # Set the color variables
+        green=$(tput setaf 2)      # Green text color
+        reset=$(tput sgr0)        # Reset text formatting
+        
+        # Loop through each line of the output
+        while IFS= read -r line; do
+          # Check if the line contains an asterisk (*)
+          if [[ $line == *"*"* ]]; then
+            # Replace the entire line with the same text but in green
+            green_line="${green}${line}${reset}"
+            echo "$green_line"
+          else
+            echo "$line"
+          fi
+        done <<< "$output"
     else
         exe docker context use "$@"
     fi

--- a/_scripts/funcs.sh
+++ b/_scripts/funcs.sh
@@ -251,7 +251,6 @@ colorize() {
         *) fault "Unknown color"
     esac
     PATTERN='^.*'"${PATTERN}"'.*$|'
-    echo "PATTERN=${PATTERN}"
     readarray stdin
     echo "${stdin[@]}" | \
         GREP_COLORS="mt=01;${COLOR}" grep --color -E "${PATTERN}"

--- a/_scripts/funcs.sh
+++ b/_scripts/funcs.sh
@@ -229,6 +229,34 @@ color() {
     echo -en "${COLOR_CODE_PREFIX}${LIGHT};${COLOR}${COLOR_CODE_SUFFIX}${TEXT}${COLOR_CODE_PREFIX}0;0${COLOR_CODE_SUFFIX}"
 }
 
+colorize() {
+    ## Highlight text patterns in stdin with ANSI color
+    set -e
+    if [[ $# -lt 2 ]]; then
+        fault "Not enough args: expected COLOR and PATTERN arguments"
+    fi
+    local COLOR=$1; shift
+    local PATTERN=$1; shift
+    check_var COLOR PATTERN
+    case "${COLOR}" in
+        "black") COLOR=30;;
+        "red") COLOR=31;;
+        "green") COLOR=32;;
+        "brown") COLOR=33;;
+        "orange") COLOR=33;;
+        "blue") COLOR=34;;
+        "purple") COLOR=35;;
+        "cyan") COLOR=36;;
+        "white") COLOR=37;;
+        *) fault "Unknown color"
+    esac
+    PATTERN='^.*'"${PATTERN}"'.*$|'
+    echo "PATTERN=${PATTERN}"
+    readarray stdin
+    echo "${stdin[@]}" | \
+        GREP_COLORS="mt=01;${COLOR}" grep --color -E "${PATTERN}"
+}
+
 element_in_array () {
   local e match="$1"; shift;
   for e; do [[ "$e" == "$match" ]] && return 0; done


### PR DESCRIPTION
Changed `d.rymcg.tech context` to display the current context in green so it stands out better.