### PR TITLE
Refactor the project help menu to reorganize the output

### DIFF
--- a/_scripts/Makefile.help
+++ b/_scripts/Makefile.help
@@ -1,4 +1,6 @@
 .PHONY: help # Show this help screen
 help:
-	@echo "Makefile help for $(realpath .):"
-	@grep -h '^.PHONY: .* #' $$(export ROOT_DIR=${ROOT_DIR}; cat ${ROOT_DIR}/_scripts/Makefile.projects | grep "Makefile" | cut -d " " -f 2 | envsubst 'ROOT_DIR=$${ROOT_DIR}') | sed 's/\.PHONY: \(.*\) # \(.*\)/make \1 \t- \2/' | expand -t25
+	@${BIN}/project_help $(realpath .) ${ROOT_DIR}/_scripts/Makefile.projects ${PROJECT_MAKEFILE}
+
+#old:
+#	@grep -h '^.PHONY: .* #' $$(export ROOT_DIR=${ROOT_DIR}; cat ${ROOT_DIR}/_scripts/Makefile.projects | grep "Makefile" | cut -d " " -f 2 | envsubst 'ROOT_DIR=$${ROOT_DIR}') | sed 's/\.PHONY: \(.*\) # \(.*\)/make \1 \t- \2/' | expand -t25

--- a/_scripts/project_help
+++ b/_scripts/project_help
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Print help messages for d.rymcg.tech project Makefiles
+
+BIN=$(dirname ${BASH_SOURCE})
+ROOT_DIR=$(dirname ${BIN})
+
+source ${BIN}/funcs.sh
+
+if [[ "$#" -lt 2 ]]; then
+    fault "Missing args {PROJECT_DIR} {Makefiles...}"
+fi
+
+PROJECT_DIR="$1"; shift
+MAKEFILES="$@"
+
+D_RYMCG_TECH_MAKEFILES="$(export ROOT_DIR=${ROOT_DIR}; cat ${MAKEFILES} | grep "Makefile" | cut -d " " -f 2 | envsubst 'ROOT_DIR=${ROOT_DIR}')"
+
+echo "# Global project targets:"
+(grep -h '^.PHONY: .* #' ${D_RYMCG_TECH_MAKEFILES} | sed 's/\.PHONY: \(.*\) # \(.*\)/make \1 \t- \2/' | expand -t25) | sort -u
+
+echo
+echo "# Project targets:"
+(grep -h '^.PHONY: .* #' ${MAKEFILES} | sed 's/\.PHONY: \(.*\) # \(.*\)/make \1 \t- \2/' | expand -t25) | sort -u
+echo


### PR DESCRIPTION
This puts all the global targets at the top and all the project specific targets below.