### PR TITLE
Fix dev-sync rsync image build

### DIFF
--- a/_scripts/funcs.sh
+++ b/_scripts/funcs.sh
@@ -248,10 +248,10 @@ volume_rsync() {
         local VOLUME="${1}"; shift
         check_var VOLUME
     fi
+    # Check that the localhost/rsync image exists, if not build it:
+    docker image inspect localhost/rsync >/dev/null || docker build -t localhost/rsync ${ROOT_DIR}/_terminal/rsync
     if [[ "${DISABLE_VOLUME_RSYNC_CHECKS}" != "true" ]]; then
         echo "Doing initial rsync checks for volume: ${VOLUME} ..."
-        # Check that the localhost/rsync image exists, if not build it:
-        docker image inspect localhost/rsync >/dev/null || docker build -t localhost/rsync ${ROOT_DIR}/_terminal/rsync
         # Check that the volume we will sync to already exists:
         if ! docker volume inspect "${VOLUME}" >/dev/null; then
             fault "You must create the '${VOLUME}' volume before running this."


### PR DESCRIPTION
Move the localhost/rsync image build outside of the `DISABLE_VOLUME_RSYNC_CHECKS` check.

This is needed to ensure the rsync image always exists 