### PR TITLE
Prometheus: adding instance and mtls

### DIFF
--- a/prometheus/.env-dist
+++ b/prometheus/.env-dist
@@ -1,6 +1,19 @@
 # The domain name for the grafana dashboard:
 PROMETHEUS_METRICS_TRAEFIK_HOST=metrics.example.com
 
+## https://hub.docker.com/r/prom/prometheus/tags
+PROMETHEUS_VERSION=v2.52.0
+## https://hub.docker.com/r/grafana/grafana/tags
+PROMETHEUS_GRAFANA_VERSION=11.0.0
+## https://hub.docker.com/r/prom/node-exporter/tags
+PROMETHEUS_NODE_EXPORTER_VERSION=v1.8.1
+## https://github.com/google/cadvisor/releases
+PROMETHEUS_CADVISOR_VERSION=v0.49.1
+## https://hub.docker.com/r/prom/alertmanager/tags
+PROMETHEUS_ALERTMANAGER_VERSION=v0.27.0
+## https://github.com/vmware-tanzu/carvel-ytt/releases
+PROMETHEUS_CONFIG_YTT_VERSION=v0.49.0
+
 PROMETHEUS_INSTANCE=
 
 PROMETHEUS_NODE_EXPORTER_ENABLED=true
@@ -14,18 +27,26 @@ DOCKER_COMPOSE_PROFILES=default,node-exporter,cadvisor
 ##Allow all access:
 PROMETHEUS_METRICS_IP_SOURCERANGE="0.0.0.0/0"
 
-## https://hub.docker.com/r/prom/prometheus/tags
-PROMETHEUS_VERSION=v2.42.0
-## https://hub.docker.com/r/grafana/grafana/tags
-PROMETHEUS_GRAFANA_VERSION=9.3.6
-## https://hub.docker.com/r/prom/node-exporter/tags
-PROMETHEUS_NODE_EXPORTER_VERSION=v1.5.0
-## https://github.com/google/cadvisor/releases
-PROMETHEUS_CADVISOR_VERSION=v0.47.0
-## https://hub.docker.com/r/prom/alertmanager/tags
-PROMETHEUS_ALERTMANAGER_VERSION=v0.25.0
-## https://github.com/vmware-tanzu/carvel-ytt/releases
-PROMETHEUS_CONFIG_YTT_VERSION=v0.43.0
+# HTTP Basic Authentication:
+# Use `make config` to fill this in properly, or set this to blank to disable.
+PROMETHEUS_HTTP_AUTH=
+
+# OAUTH2
+# Set to `true` to use OpenID/OAuth2 authentication via the
+# traefik-forward-auth service in d.rymcg.tech.
+# Using OpenID/OAuth2 will require login to access your app,
+# but it will not affect what a successfully logged-in person can do in your
+# app. If your app has built-in authentication and can check the user
+# header that traefik-forward-auth sends, then your app can limit what the
+# logged-in person can do in the app. But if your app can't check the user
+# header, or if your app doesn't have built-in authentication at all, then
+# any person with an account on your Gitea server can log into your app and
+# have full access.
+PROMETHEUS_OAUTH2=
+# In addition to Oauth2 authentication, you can configure basic authorization
+# by entering which authorization group can log into your app. You create
+# groups of email addresses in the `traefik` folder by running `make groups`. 
+PROMETHEUS_OAUTH2_AUTHORIZED_GROUP=
 
 PROMETHEUS_ALERTMANAGER_SMTP_ENABLED=false
 PROMETHEUS_ALERTMANAGER_SMTP_SMARTHOST=smtp.example.com:465
@@ -38,3 +59,10 @@ PROMETHEUS_MEMORY_LIMIT=500M
 PROMETHEUS_GRAFANA_MEMORY_LIMIT=500M
 PROMETHEUS_CADVISOR_MEMORY_LIMIT=500M
 PROMETHEUS_ALERTMANAGER_MEMORY_LIMIT=500M
+
+# Mutual TLS (mTLS):
+# Set true or false. If true, all clients must present a certificate signed by Step-CA:
+PROMETHEUS_MTLS_AUTH=false
+# Enter a comma separated list of client domains allowed to connect via mTLS.
+# Wildcards are allowed and encouraged on a per-app basis:
+PROMETHEUS_MTLS_AUTHORIZED_CERTS=*.clients.whoami.example.com

--- a/prometheus/Makefile
+++ b/prometheus/Makefile
@@ -6,6 +6,7 @@ include ${ROOT_DIR}/_scripts/Makefile.instance
 config-hook:
 	@${BIN}/reconfigure_ask ${ENV_FILE} PROMETHEUS_METRICS_TRAEFIK_HOST "Enter the metrics portal domain name" metrics${INSTANCE_URL_SUFFIX}.${ROOT_DOMAIN}
 	@${BIN}/reconfigure ${ENV_FILE} PROMETHEUS_INSTANCE=$${instance:-default}
+	@${BIN}/reconfigure_auth ${ENV_FILE} PROMETHEUS
 	@echo
 	@${BIN}/confirm $$(test "$$(${BIN}/dotenv -f ${ENV_FILE} get PROMETHEUS_NODE_EXPORTER_ENABLED)" == true && echo yes || echo no) "Do you want to run node-exporter to collect the Host system metrics" "?" && ${BIN}/reconfigure ${ENV_FILE} PROMETHEUS_NODE_EXPORTER_ENABLED=true || ${BIN}/reconfigure ${ENV_FILE} PROMETHEUS_NODE_EXPORTER_ENABLED=false
 	@echo
@@ -22,6 +23,20 @@ config-hook:
 	@echo
 	@make --no-print-directory compose-profiles
 
+.PHONY: override-hook
+override-hook:
+#### This sets the override template variables for docker-compose.instance.yaml:
+#### The template dynamically renders to docker-compose.override_{DOCKER_CONTEXT}_{INSTANCE}.yaml
+#### These settings are used to automatically generate the service container labels, and traefik config, inside the template.
+#### The variable arguments have three forms: `=` `=:` `=@`
+####   name=VARIABLE_NAME    # sets the template 'name' field to the value of VARIABLE_NAME found in the .env file
+####                         # (this hardcodes the value into docker-compose.override.yaml)
+####   name=:VARIABLE_NAME   # sets the template 'name' field to the literal string 'VARIABLE_NAME'
+####                         # (this hardcodes the string into docker-compose.override.yaml)
+####   name=@VARIABLE_NAME   # sets the template 'name' field to the literal string '${VARIABLE_NAME}'
+####                         # (used for regular docker-compose expansion of env vars by name.)
+	@${BIN}/docker_compose_override ${ENV_FILE} project=:prometheus instance=@PROMETHEUS_INSTANCE traefik_host=@PROMETHEUS_METRICS_TRAEFIK_HOST http_auth=PROMETHEUS_HTTP_AUTH http_auth_var=@PROMETHEUS_HTTP_AUTH ip_sourcerange=@PROMETHEUS_METRICS_IP_SOURCERANGE oauth2=PROMETHEUS_OAUTH2 authorized_group=PROMETHEUS_OAUTH2_AUTHORIZED_GROUP enable_mtls_auth=PROMETHEUS_MTLS_AUTH mtls_authorized_certs=PROMETHEUS_MTLS_AUTHORIZED_CERTS
+	
 .PHONY: compose-profiles
 compose-profiles:
 	@${BIN}/reconfigure_compose_profiles ${ENV_FILE} PROMETHEUS_NODE_EXPORTER_ENABLED=node-exporter PROMETHEUS_CADVISOR_ENABLED=cadvisor PROMETHEUS_ALERTMANAGER_ENABLED=alertmanager
@@ -30,11 +45,11 @@ compose-profiles:
 shell:
 	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'node-exporter' 'prometheus' 'grafana' 'cadvisor' 'alertmanager' 'alert-test' --default 'grafana'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
 
-.PHONY: local-alertmanager
+.PHONY: local-alertmanager # need summary here
 local-alertmanager:
 	@export ENV_FILE=${ENV_FILE} CONTEXT_INSTANCE=${CONTEXT_INSTANCE} PORT_FORWARD="$$(${BIN}/port_forward ${ENV_FILE} alertmanager 9093)"; if [[ ! "$${PORT_FORWARD}" =~ [0-9]+ ]]; then ${BIN}/fault "Could not get the SSH forwarded port"; else echo "Local port forward established on localhost:$${PORT_FORWARD}"; fi;
 
-.PHONY: test-alert
+.PHONY: test-alert # need summary here
 test-alert:
 	@docker compose --env-file ${ENV_FILE} run --rm -it alert-test
 	@echo 

--- a/prometheus/Makefile
+++ b/prometheus/Makefile
@@ -45,11 +45,11 @@ compose-profiles:
 shell:
 	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'node-exporter' 'prometheus' 'grafana' 'cadvisor' 'alertmanager' 'alert-test' --default 'grafana'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
 
-.PHONY: local-alertmanager # need summary here
+.PHONY: local-alertmanager # Forward alerts to local environment
 local-alertmanager:
 	@export ENV_FILE=${ENV_FILE} CONTEXT_INSTANCE=${CONTEXT_INSTANCE} PORT_FORWARD="$$(${BIN}/port_forward ${ENV_FILE} alertmanager 9093)"; if [[ ! "$${PORT_FORWARD}" =~ [0-9]+ ]]; then ${BIN}/fault "Could not get the SSH forwarded port"; else echo "Local port forward established on localhost:$${PORT_FORWARD}"; fi;
 
-.PHONY: test-alert # need summary here
+.PHONY: test-alert # Perform a test alert
 test-alert:
 	@docker compose --env-file ${ENV_FILE} run --rm -it alert-test
 	@echo 

--- a/prometheus/docker-compose.instance.yaml
+++ b/prometheus/docker-compose.instance.yaml
@@ -1,0 +1,65 @@
+#! This is a ytt template file for docker-compose.override.yaml
+#! References:
+#!   https://carvel.dev/ytt
+#!   https://docs.docker.com/compose/extends/#adding-and-overriding-configuration
+#!   https://github.com/enigmacurry/d.rymcg.tech#overriding-docker-composeyaml-per-instance
+
+#! ### Standard project vars:
+#@ load("@ytt:data", "data")
+#@ project = data.values.project
+#@ instance = data.values.instance
+#@ context = data.values.context
+#@ traefik_host = data.values.traefik_host
+#@ ip_sourcerange = data.values.ip_sourcerange
+#@ enable_http_auth = len(data.values.http_auth.strip()) > 0
+#@ http_auth = data.values.http_auth_var
+#@ enable_oauth2 = data.values.oauth2 == "true"
+#@ authorized_group = data.values.authorized_group
+#@ enable_mtls_auth = data.values.enable_mtls_auth == "true"
+#@ mtls_authorized_certs = data.values.mtls_authorized_certs
+#@ enabled_middlewares = []
+
+#@yaml/text-templated-strings
+services:
+  grafana:
+    #@ service = "grafana"
+    labels:
+      #! Services must opt-in to be proxied by Traefik:
+      - "traefik.enable=true"
+
+      #! 'router' is the fully qualified key in traefik for this router/service: project + instance + service
+      #@ router = "{}-{}-{}".format(project,instance,service)
+
+      #! The host matching router rule:
+      - "traefik.http.routers.(@= router @).rule=Host(`(@= traefik_host @)`)"
+      - "traefik.http.routers.(@= router @).entrypoints=websecure"
+
+      #@ enabled_middlewares.append("{}-ipallowlist".format(router))
+      - "traefik.http.middlewares.(@= router @)-ipallowlist.ipallowlist.sourcerange=(@= ip_sourcerange @)"
+      #@ if enable_http_auth:
+      #@ enabled_middlewares.append("{}-basicauth".format(router))
+      - "traefik.http.middlewares.(@= router @)-basicauth.basicauth.users=(@= http_auth @)"
+      - "traefik.http.middlewares.(@= router @)-basicauth.basicauth.headerField=X-Forwarded-User"
+      #@ end
+
+      #@ if enable_oauth2:
+      #@ enabled_middlewares.append("traefik-forward-auth@docker")
+      #@ enabled_middlewares.append("header-authorization-group-{}@file".format(authorized_group))
+      #@ end
+
+      #@ if enable_mtls_auth:
+      - "traefik.http.routers.(@= router @).tls.options=step_ca_mTLS@file"
+        #@ if len(mtls_authorized_certs):
+      - "traefik.http.middlewares.mtlsauth-(@= router @).plugin.certauthz.domains=(@= mtls_authorized_certs @)"
+        #@ enabled_middlewares.append("mtlsauth-{}".format(router))
+        #@ end
+        #@ enabled_middlewares.append("mtls-header@file")
+      #@ end
+      
+      #! Override the default port that the app binds to:
+      #! You don't normally need to do this, as long as your image has
+      #! an EXPOSE directive in it, Traefik will autodetect it, but this is how you can override it:
+      - "traefik.http.services.(@= router @).loadbalancer.server.port=8000"
+
+      #! Apply all middlewares (do this at the end!)
+      - "traefik.http.routers.(@= router @).middlewares=(@= ','.join(enabled_middlewares) @)"

--- a/prometheus/docker-compose.instance.yaml
+++ b/prometheus/docker-compose.instance.yaml
@@ -56,10 +56,5 @@ services:
         #@ enabled_middlewares.append("mtls-header@file")
       #@ end
       
-      #! Override the default port that the app binds to:
-      #! You don't normally need to do this, as long as your image has
-      #! an EXPOSE directive in it, Traefik will autodetect it, but this is how you can override it:
-      - "traefik.http.services.(@= router @).loadbalancer.server.port=8000"
-
       #! Apply all middlewares (do this at the end!)
       - "traefik.http.routers.(@= router @).middlewares=(@= ','.join(enabled_middlewares) @)"

--- a/prometheus/docker-compose.yaml
+++ b/prometheus/docker-compose.yaml
@@ -21,7 +21,6 @@ services:
       - PROMETHEUS_ALERTMANAGER_SMTP_AUTH_PASSWORD
       - PROMETHEUS_ALERTMANAGER_SMTP_FROM
       - PROMETHEUS_ALERTMANAGER_SMTP_TO
-
     volumes:
       - prometheus_config:/etc/prometheus
       - alertmanager_config:/etc/alertmanager
@@ -77,12 +76,7 @@ services:
     restart: unless-stopped
     volumes:
       - grafana:/var/lib/grafana
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.prometheus-grafana-${PROMETHEUS_INSTANCE:-default}.rule=Host(`${PROMETHEUS_METRICS_TRAEFIK_HOST}`)"
-      - "traefik.http.routers.prometheus-grafana-${PROMETHEUS_INSTANCE:-default}.entrypoints=websecure"
-      - "traefik.http.middlewares.prometheus-${PROMETHEUS_INSTANCE:-default}-whitelist.ipallowlist.sourcerange=${PROMETHEUS_METRICS_IP_SOURCERANGE}"
-      - "traefik.http.routers.prometheus-${PROMETHEUS_INSTANCE:-default}.middlewares=prometheus-${PROMETHEUS_INSTANCE:-default}-whitelist"
+    labels: []
     deploy:
       resources:
         limits:


### PR DESCRIPTION
I'm working on adding instance and mtls to Prometheus.

In my local .env, Prometheus was working in my VPN. The only things I changed are commited here, but now I get "Bad Gateway". I'm testing with Prometheus in my VPN but I don't have any sentry authentication in front of it.

There don't appear to be any errors in Prometheus' logs, but this is in Traefik's log:
```
traefik-1      | time="2024-06-06T01:04:43Z" level=error msg="sourceRange is empty, IPAllowLister not created" entryPointName=websecure routerName=prometheus-default-prometheus@docker
```
But I have `PROMETHEUS_METRICS_IP_SOURCERANGE="0.0.0.0/0"` in my .env and Traefik seems to see the IPAllowList value:
![image](https://github.com/EnigmaCurry/d.rymcg.tech/assets/46011270/7d80e63c-a8ff-464b-84ed-f0d56de6406f)

