### PR TITLE
add mtls to ttrss

### DIFF
--- a/ttrss/.env-dist
+++ b/ttrss/.env-dist
@@ -34,4 +34,4 @@ TTRSS_OAUTH2_AUTHORIZED_GROUP=
 TTRSS_MTLS_AUTH=false
 # Enter a comma separated list of client domains allowed to connect via mTLS.
 # Wildcards are allowed and encouraged on a per-app basis:
-TTRSS_MTLS_AUTHORIZED_CERTS=*.clients.whoami.example.com
+TTRSS_MTLS_AUTHORIZED_CERTS=*.clients.ttrss.example.com

--- a/ttrss/.env-dist
+++ b/ttrss/.env-dist
@@ -28,3 +28,10 @@ TTRSS_OAUTH2=
 # by entering which authorization group can log into your app. You create
 # groups of email addresses in the `traefik` folder by running `make groups`.
 TTRSS_OAUTH2_AUTHORIZED_GROUP=
+
+# Mutual TLS (mTLS):
+# Set true or false. If true, all clients must present a certificate signed by Step-CA:
+TTRSS_MTLS_AUTH=false
+# Enter a comma separated list of client domains allowed to connect via mTLS.
+# Wildcards are allowed and encouraged on a per-app basis:
+TTRSS_MTLS_AUTHORIZED_CERTS=*.clients.whoami.example.com

--- a/ttrss/Makefile
+++ b/ttrss/Makefile
@@ -25,7 +25,7 @@ override-hook:
 ####                         # (this hardcodes the string into docker-compose.override.yaml)
 ####   name=@VARIABLE_NAME   # sets the template 'name' field to the literal string '${VARIABLE_NAME}'
 ####                         # (used for regular docker-compose expansion of env vars by name.)
-	@${BIN}/docker_compose_override ${ENV_FILE} project=:ttrss instance=@TTRSS_INSTANCE traefik_host=@TTRSS_TRAEFIK_HOST http_auth=TTRSS_HTTP_AUTH http_auth_var=@TTRSS_HTTP_AUTH ip_sourcerange=@TTRSS_IP_SOURCERANGE oauth2=TTRSS_OAUTH2 authorized_group=TTRSS_OAUTH2_AUTHORIZED_GROUP
+	@${BIN}/docker_compose_override ${ENV_FILE} project=:ttrss instance=@TTRSS_INSTANCE traefik_host=@TTRSS_TRAEFIK_HOST http_auth=TTRSS_HTTP_AUTH http_auth_var=@TTRSS_HTTP_AUTH ip_sourcerange=@TTRSS_IP_SOURCERANGE oauth2=TTRSS_OAUTH2 authorized_group=TTRSS_OAUTH2_AUTHORIZED_GROUP enable_mtls_auth=TTRSS_MTLS_AUTH mtls_authorized_certs=TTRSS_MTLS_AUTHORIZED_CERTS
 
 .PHONY: shell
 shell:

--- a/ttrss/docker-compose.instance.yaml
+++ b/ttrss/docker-compose.instance.yaml
@@ -15,6 +15,8 @@
 #@ http_auth = data.values.http_auth_var
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
+#@ enable_mtls_auth = data.values.enable_mtls_auth == "true"
+#@ mtls_authorized_certs = data.values.mtls_authorized_certs
 #@ enabled_middlewares = []
 
 #@yaml/text-templated-strings
@@ -43,6 +45,15 @@ services:
       #@ if enable_oauth2:
       #@ enabled_middlewares.append("traefik-forward-auth@docker")
       #@ enabled_middlewares.append("header-authorization-group-{}@file".format(authorized_group))
+      #@ end
+
+      #@ if enable_mtls_auth:
+      - "traefik.http.routers.(@= router @).tls.options=step_ca_mTLS@file"
+        #@ if len(mtls_authorized_certs):
+      - "traefik.http.middlewares.mtlsauth-(@= router @).plugin.certauthz.domains=(@= mtls_authorized_certs @)"
+        #@ enabled_middlewares.append("mtlsauth-{}".format(router))
+        #@ end
+        #@ enabled_middlewares.append("mtls-header@file")
       #@ end
 
       #! Apply all middlewares (do this at the end!)


### PR DESCRIPTION
Added mTLS to TTRSS and it works fine if you use TTRSS from its web UI. But if you use a client app (e.g., the official [Tiny Tiny RSS for Android](https://gitlab.tt-rss.org/tt-rss/tt-rss-android), or third party Android apps like TTRSS-Reader, Tiny Tiny Feed, Geekttrss), the client app can't connect to the TTRSS Server.

TTRSS does [support SSL cert auth](https://tt-rss.org/wiki/SSL%20Certificate%20Authentication), but _if_ that's going to allow client apps to access the TTRSS server via mTLS, installation of TTRSS might need to be something like:

1. `d make step-ca cert` to create the cert you want your android app to use
2.  `d make ttrss config` would ask which cert in `step-ca/certs` you want to use
3. `d make ttrss install` would build container with `Dockerfile`:
    1. copying the cert to correct directory in web-nginx container
    2. running `sudo update-ca-certificates` in web-nginx container
    3. modifying nginx.conf in web-nginx container
    4. restarting nginx in web-nginx container
5. `d make ttrss install`  would shred the selected cert files (or maybe ask user first)
6. `d make ttrss open` and in TTRSS UI, go to Preferences and scroll to the bottom; under "Login with an SSL certificate" the "Register" button should now be available - click it, then Save configuration.

This PR is probably worth merging as-is, in case someone wants to use TTRSS strictly from its web UI and wants mTLS. But I don't think it's worth the effort of making mTLS work with TTRSS client apps. The official app has support for HTTP Basic Auth.