### PR TITLE
Centralize authentication info from readmes

### DIFF
--- a/AUTH.md
+++ b/AUTH.md
@@ -1,0 +1,40 @@
+# Authentication and Authorization
+
+Running `make config` for an app will ask whether or not you want to configure
+authentication for your app (on top of any authentication your app provides).
+You can configure OpenID/OAuth2, mTLS, or HTTP Basic Authentication (or you
+can opt to not install any authentication on top of your app).
+
+OAuth2 uses traefik-forward-auth to delegate authentication to an external
+authority (eg. a self-deployed Forgejo instance). Accessing an app though
+OAuth2 will require all users to login through that external service first.
+Once authenticated, they may be authorized access only if their login id
+matches the member list of the predefined authorization group configured for
+the app (`<APPNAME>_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined
+in the Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
+[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
+by running `d make traefik config`, selecting "Config", selecting "Middleware",
+and selecting "Oauth2 sentry authorization"
+([traefik-forward-auth](https://github.com/EnigmaCurry/d.rymcg.tech/tree/master/traefik-forward-auth)
+must be installed).
+
+mTLS (Mutual TLS) is an extension of standard TLS where both the client and
+server authenticate each other using certificates. Accessing an app through
+mTLS will require all users to have a client mTLS certificate installed in
+their browser, and the app must be configured to accept that certificate. You
+will be prompted to enter one or more CN (Common Name) in a comma-separated
+list (a CN is a field in a certificate that typically represents the domain
+name of the server or the person/organization to which the certificate is
+issued). Only certificates matching one of these CNs will be allowed access to
+the app, and users with a valid mTLS certificate will be ensured secure,
+two-way encrypted communication, providing enhanced security by verifying both
+parties' identities.
+
+For HTTP Basic Authentication, you will be prompted to enter one or more
+username/password logins which are stored in that app's `.env_{CONTEXT}_{INSTANCE}`
+file. Accessing an app through HTTP Basic Authentication will require all
+users to enter a login name and password in their browser, and they may be
+authorized access to the app only if their login name and password match one
+that you configured for the app. *Note:* Browsers themselves prompt the user
+for their login credentials, not a web page; so if someone is using a password
+manager, it likely won't be able to automate this type of login.

--- a/archivebox/README.md
+++ b/archivebox/README.md
@@ -4,14 +4,13 @@
 website archiving tool to collect, save, and view sites that you want to
 preserve offline (`.html`, `.pdf`, `.warc`).
 
-This configuration includes HTTP Basic Authentication, effectively making the
-entire site private. ArchiveBox has its own authentication system that is an
-additional security layer, but only for the administrative functions. If you
-wish the site to be public, comment out the `Authentication` secton of the
-`docker-compose.yaml`.
-
 If you are new to d.rymcg.tech, make sure to read the main
 [README.md](../README.md) first.
+
+## Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Config
 

--- a/audiobookshelf/README.md
+++ b/audiobookshelf/README.md
@@ -17,22 +17,8 @@ It automatically saves your responses into the configuration file
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2 or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`AUDIOBOOKSHELF_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `make groups` in the `traefik` directory.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Install
 

--- a/baikal/README.md
+++ b/baikal/README.md
@@ -8,6 +8,11 @@ accordingly.
  * `BAIKAL_TRAEFIK_HOST` to the external domain name forwarded from traefik, eg.
    `cal.example.com`
 
+## Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
 Run `make install`
 
 Immediately configure the application, it is insecure by default until

--- a/calcpad/README.md
+++ b/calcpad/README.md
@@ -7,6 +7,17 @@ take on the calculator.
 
 ```
 make config
+```
+
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
+```
 make install
+```
+
+```
 make open
 ```

--- a/calibre/README.md
+++ b/calibre/README.md
@@ -21,6 +21,11 @@ pre-baked username and password necessary to login the first time:
 After you login, and change the default password, you can then
 consider turning off the sentry authorization.
 
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
 ## Install
 
 ```

--- a/drawio/README.md
+++ b/drawio/README.md
@@ -19,24 +19,8 @@ It automatically saves your responses into the configuration file
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2 or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`DRAWIO_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `make groups` in the `traefik` directory.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
-
-
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Install
 

--- a/filestash/README.md
+++ b/filestash/README.md
@@ -3,6 +3,11 @@
 [Filestash](https://github.com/mickael-kerjean/filestash) is a web-based file
 manager, connecting to many different storage backends.
 
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
 This configuration requires HTTP Basic Authentication in front of the
 application. This is due to the fact that **I consider filestash to be
 insecure by default**, and because it performs the backend

--- a/forgejo/README.md
+++ b/forgejo/README.md
@@ -20,6 +20,13 @@ format](https://codeberg.org/forgejo/forgejo/src/branch/forgejo/contrib/environm
 but make sure you also copy the added variable names to the
 `docker-compose.yaml` environment section, otherwise they will not be seen.
 
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app. *Note:* You can't add Oauth2 on top of Forgejo because Forgejo
+would then try to access itself to see if the user had access to Forgejo, but
+it couldn't access itself without access - this recursion wouldn't work.
+
 ## Initial setup
 
 Bring up the service with `make install`, then immediately open the

--- a/freshrss/README.md
+++ b/freshrss/README.md
@@ -10,6 +10,11 @@ Run `make config` or copy `.env-dist` to
  * `FRESHRSS_TRAEFIK_HOST` the domain name for FreshRSS.
  * `TIME_ZONE` the timezone of the server
 
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
 Bring up the server : `make install`
 
 Open the browser page: `make open`

--- a/glances/README.md
+++ b/glances/README.md
@@ -38,34 +38,8 @@ containers, and potentially compromise the host system.
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2, mTLS, or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`GLANCES_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `make groups` in the `traefik` directory.
-
-mTLS (Mutual TLS) is an extension of standard TLS where both the client and
-server authenticate each other using certificates. Accessing this app will
-require all users to have a client mTLS certificate installed in their browser,
-and this app must be configured to accept that certificate. You will be
-prompted to enter one or more CN (Common Name) in a comma-separated list (a CN
-is a field in a certificate that typically represents the domain name of the
-server or the person/organization to which the certificate is issued). Only
-certificates matching one of these CNs will be allowed access to the app, and
-users with a valid mTLS certificate will be ensured secure, two-way encrypted
-communication, providing enhanced security by verifying both parties'
-identities.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Install
 

--- a/grocy/README.md
+++ b/grocy/README.md
@@ -18,23 +18,8 @@ It automatically saves your responses into the configuration file
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2 or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`GROCY_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `make groups` in the `traefik` directory.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
-
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Install
 

--- a/homepage/README.md
+++ b/homepage/README.md
@@ -40,23 +40,8 @@ file.
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2 or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`HOMEPAGE_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `make groups` in the `traefik` directory.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
-
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Generate deploy key (if using a private template repository)
 

--- a/immich/README.md
+++ b/immich/README.md
@@ -16,37 +16,8 @@ It automatically saves your responses into the configuration file
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2, mTLS, or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`IMMICH_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `d make traefik config`, selecting "Config", selecting "Middleware",
-and selecting "Oauth2 sentry authorization"
-([traefik-forward-auth](https://github.com/EnigmaCurry/d.rymcg.tech/tree/master/traefik-forward-auth)
-must be installed).
-
-mTLS (Mutual TLS) is an extension of standard TLS where both the client and
-server authenticate each other using certificates. Accessing this app will
-require all users to have a client mTLS certificate installed in their browser,
-and this app must be configured to accept that certificate. You will be
-prompted to enter one or more CN (Common Name) in a comma-separated list (a CN
-is a field in a certificate that typically represents the domain name of the
-server or the person/organization to which the certificate is issued). Only
-certificates matching one of these CNs will be allowed access to the app, and
-users with a valid mTLS certificate will be ensured secure, two-way encrypted
-communication, providing enhanced security by verifying both parties'
-identities.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Install
 

--- a/invidious/README.md
+++ b/invidious/README.md
@@ -17,23 +17,8 @@ It automatically saves your responses into the configuration file
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2 or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`INVIDIOUS_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `make groups` in the `traefik` directory.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
-
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ```
 make install

--- a/jupyterlab/README.md
+++ b/jupyterlab/README.md
@@ -5,6 +5,11 @@ progamming notebook, for Python and other languages.
 
 Run `make config` and set the jupyterlab domain name.
 
+## Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
 Run `make install` to deploy it.
 
 Run `watch make status` and wait for the service to come online with

--- a/larynx/README.md
+++ b/larynx/README.md
@@ -10,6 +10,11 @@ available. If you know how to fix it, please send a PR.
 Run `make config` to configure the larynx domain name and
 username/password.
 
+## Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
 Run `make install` to deploy the app.
 
 Run `make open` to open the page in your browser.

--- a/lemmy/README.md
+++ b/lemmy/README.md
@@ -13,8 +13,12 @@ This will ask you to enter the domain name to use.
 It automatically saves your responses into the configuration file
 `.env_{INSTANCE}`.
 
-### Auth
+### Authentication and Authorization
 
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
+*NOTE:*
 If you turn on the Traefik auth middlewares, Lemmy cannot federate
 properly (not even to pull from other instances). However, with auth
 turned on, the app will still work as a fully private instance.

--- a/minio/README.md
+++ b/minio/README.md
@@ -16,6 +16,11 @@ web based file manager.
 make config
 ```
 
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
 ## Limiting traffic
 
 You can limit traffic based on source IP address for either or both of these

--- a/nextcloud/README.md
+++ b/nextcloud/README.md
@@ -32,22 +32,8 @@ Optionally, you can store this data externally in an S3 Bucket instead.
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2 or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`WHOAMI_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `make groups` in the `traefik` directory.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Install
 

--- a/nodered/README.md
+++ b/nodered/README.md
@@ -7,6 +7,11 @@ hardware devices, APIs and online services in new and interesting ways.
 make config
 ```
 
+## Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
 ```
 make install
 ```

--- a/ntfy-sh/README.md
+++ b/ntfy-sh/README.md
@@ -15,6 +15,11 @@ usage of network and battery resources.
 make config
 ```
 
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
 ## Install
 
 ```

--- a/pairdrop/README.md
+++ b/pairdrop/README.md
@@ -7,7 +7,22 @@
 
 ```
 make config
+```
+
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
+## Install
+
+```
 make install
+```
+
+## Open
+
+```
 make open
 ```
 

--- a/peertube/README.md
+++ b/peertube/README.md
@@ -23,25 +23,10 @@ This will ask you to enter the domain name to use.
 To use Peertube's livestreaming, you have to enable either the RTMP or RTMPS
 Traefik entrypoint.
 
-
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2 or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`PEERTUBE_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `make groups` in the `traefik` directory.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Install
 

--- a/photoprism/README.md
+++ b/photoprism/README.md
@@ -13,7 +13,6 @@ This will ask you to enter the domain name to use.
 It automatically saves your responses into the configuration file
 `.env_{INSTANCE}`.
 
-
 You'll also be prompted to enter a few configurations for PhotoPrism,
 but there are other Photoprism options you can configure by manually
 editing your `.env_{DOCKER_CONTEXT}` file. If you add more media volumes,
@@ -23,23 +22,8 @@ import volume, be sure to uncomment the corresponding line in the
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2 or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`PHOTOPRISM_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `make groups` in the `traefik` directory.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
-
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Install
 

--- a/piwigo/README.md
+++ b/piwigo/README.md
@@ -24,23 +24,8 @@ Alternatively to running `make config`, you can manually copy
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2 or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`PIWIGO_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `make groups` in the `traefik` directory.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
-
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 
 Once the `.env_${DOCKER_CONTEXT}_default` file is configured install piwigo:

--- a/privatebin/README.md
+++ b/privatebin/README.md
@@ -7,6 +7,11 @@ open source online pastebin where the server has zero knowledge of pasted data.
 
 `make config`
 
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
 ## Install
 
 `make install`

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -24,6 +24,11 @@ make config
 * Choose whether to run node-exporter or not (For collecting the Host metrics).
 * Choose whether to run cAdvisor or not (For collecting container metrics).
 
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
 ```
 make install
 ```

--- a/qbittorrent-wireguard/README.md
+++ b/qbittorrent-wireguard/README.md
@@ -119,6 +119,11 @@ use the default:
    protected by username/password or IP filter). You can modify this
    to access certain peers that dont' need a VPN (eg. on your LAN).
 
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
 ## Deploy
 
 Once configured, deploy it:

--- a/redmine/README.md
+++ b/redmine/README.md
@@ -15,22 +15,8 @@ It automatically saves your responses into the configuration file
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2 or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`WHOAMI_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `make groups` in the `traefik` directory.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Install
 

--- a/s3-proxy/README.md
+++ b/s3-proxy/README.md
@@ -13,8 +13,10 @@ these into your `.env_${DOCKER_CONTEXT}_default` file.
 
 Run `make config`. 
 
-If public access is desired without any username/password required, comment out
-the `Authentication` section in `docker-compose.yaml`.
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Limiting traffic
 

--- a/searxng/README.md
+++ b/searxng/README.md
@@ -15,34 +15,8 @@ It automatically saves your responses into the configuration file
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2, mTLS, or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`SEARXNG_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `make groups` in the `traefik` directory.
-
-mTLS (Mutual TLS) is an extension of standard TLS where both the client and
-server authenticate each other using certificates. Accessing this app will
-require all users to have a client mTLS certificate installed in their browser,
-and this app must be configured to accept that certificate. You will be
-prompted to enter one or more CN (Common Name) in a comma-separated list (a CN
-is a field in a certificate that typically represents the domain name of the
-server or the person/organization to which the certificate is issued). Only
-certificates matching one of these CNs will be allowed access to the app, and
-users with a valid mTLS certificate will be ensured secure, two-way encrypted
-communication, providing enhanced security by verifying both parties'
-identities.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Install
 

--- a/shaarli/README.md
+++ b/shaarli/README.md
@@ -3,6 +3,15 @@
 [Shaarli](https://github.com/shaarli/Shaarli) is a personal, minimalist,
 super-fast, database free, bookmarking service.
 
+## Setup
+
 Run `make config` and configure the domain name.
+
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
+## Install
 
 Run `make install` to deploy.

--- a/tesseract/README.md
+++ b/tesseract/README.md
@@ -18,37 +18,8 @@ It automatically saves your responses into the configuration file
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2, mTLS, or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`TESSERACT_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `d make traefik config`, selecting "Config", selecting "Middleware",
-and selecting "Oauth2 sentry authorization"
-([traefik-forward-auth](https://github.com/EnigmaCurry/d.rymcg.tech/tree/master/traefik-forward-auth)
-must be installed).
-
-mTLS (Mutual TLS) is an extension of standard TLS where both the client and
-server authenticate each other using certificates. Accessing this app will
-require all users to have a client mTLS certificate installed in their browser,
-and this app must be configured to accept that certificate. You will be
-prompted to enter one or more CN (Common Name) in a comma-separated list (a CN
-is a field in a certificate that typically represents the domain name of the
-server or the person/organization to which the certificate is issued). Only
-certificates matching one of these CNs will be allowed access to the app, and
-users with a valid mTLS certificate will be ensured secure, two-way encrypted
-communication, providing enhanced security by verifying both parties'
-identities.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Install
 

--- a/thirteenft/README.md
+++ b/thirteenft/README.md
@@ -21,22 +21,8 @@ It automatically saves your responses into the configuration file
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2 or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`THIRTEENFT_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `make groups` in the `traefik` directory.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Install
 

--- a/thttpd/README.md
+++ b/thttpd/README.md
@@ -16,6 +16,11 @@ they will be copied into the initial volume created. You can also use
 the [sftp](../sftp) service, and upload new files into the shared
 volume (`thttpd_files` or `thttpd_${INSTANCE}_files`).
 
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
 ## Install
 
 Run `make install`

--- a/ttrss/README.md
+++ b/ttrss/README.md
@@ -9,6 +9,11 @@ Run `make config` and answer the following questions:
 
  * Set `TTRSS_TRAEFIK_HOST` set to the domain name for your instance of ttrss.
 
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
 ## Install
 
 Run `make install`

--- a/vaultwarden/README.md
+++ b/vaultwarden/README.md
@@ -12,6 +12,11 @@ Check the config in the `.env_${DOCKER_CONTEXT}_${INSTANCE}` file.
 Check that the pinned `VAULTWARDEN_VERSION` is actually the latest
 version.
 
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
 ```
 make install
 ```

--- a/whoami/README.md
+++ b/whoami/README.md
@@ -16,22 +16,8 @@ It automatically saves your responses into the configuration file
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2 or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`WHOAMI_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `make groups` in the `traefik` directory.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Install
 

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -34,23 +34,8 @@ you want:
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2 or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`WORDPRESS_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `make groups` in the `traefik` directory.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
-
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ```
 make install

--- a/xbs/README.md
+++ b/xbs/README.md
@@ -15,6 +15,15 @@ include any custom settings you wish to run on your service. Important:
 the db.host value should match the container name of the "db" service in
 xbs/docker-compose.yml.
 
+### Authentication and Authorization
+
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
+
+*Note:* If your XBrowserSync instance is protected by authentication, the
+browser extension probably won't be able to connect to it, preventing it from
+working.
+
 ## Install
 
 ```

--- a/yourls/README.md
+++ b/yourls/README.md
@@ -16,37 +16,8 @@ It automatically saves your responses into the configuration file
 
 ### Authentication and Authorization
 
-Running `make config` will ask whether or not you want to configure
-authentication for your app (on top of any authentication your app provides).
-You can configure OpenID/OAuth2, mTLS, or HTTP Basic Authentication.
-
-OAuth2 uses traefik-forward-auth to delegate authentication to an external
-authority (eg. a self-deployed Gitea instance). Accessing this app will
-require all users to login through that external service first. Once
-authenticated, they may be authorized access only if their login id matches the
-member list of the predefined authorization group configured for the app
-(`YOURLS_OAUTH2_AUTHORIZED_GROUP`). Authorization groups are defined in the
-Traefik config (`TRAEFIK_HEADER_AUTHORIZATION_GROUPS`) and can be
-[created/modified](https://github.com/EnigmaCurry/d.rymcg.tech/blob/master/traefik/README.md#oauth2-authentication)
-by running `d make traefik config`, selecting "Config", selecting "Middleware",
-and selecting "Oauth2 sentry authorization"
-([traefik-forward-auth](https://github.com/EnigmaCurry/d.rymcg.tech/tree/master/traefik-forward-auth)
-must be installed).
-
-mTLS (Mutual TLS) is an extension of standard TLS where both the client and
-server authenticate each other using certificates. Accessing this app will
-require all users to have a client mTLS certificate installed in their browser,
-and this app must be configured to accept that certificate. You will be
-prompted to enter one or more CN (Common Name) in a comma-separated list (a CN
-is a field in a certificate that typically represents the domain name of the
-server or the person/organization to which the certificate is issued). Only
-certificates matching one of these CNs will be allowed access to the app, and
-users with a valid mTLS certificate will be ensured secure, two-way encrypted
-communication, providing enhanced security by verifying both parties'
-identities.
-
-For HTTP Basic Authentication, you will be prompted to enter username/password
-logins which are stored in that app's `.env_{INSTANCE}` file.
+See [AUTH.md](../AUTH.md) for information on adding external authentication on
+top of your app.
 
 ## Install
 


### PR DESCRIPTION
I didn't modify the following README.md files, not knowing whether the apps need customized auth info in their own README.md, or don't need any auth at all.
- filestash
- forgejo
- maubot
- nginx
- ntfy
- redbean
- sftp
- smokeping
- sysbox-systemd
- websocketd