### PR TITLE
Remove default username/password for YOURLS

### DIFF
--- a/immich/Makefile
+++ b/immich/Makefile
@@ -23,7 +23,7 @@ config-hook:
 			${BIN}/reconfigure ${ENV_FILE} IMMICH_USE_EXTERNAL_VOLUME=false; \
 		fi
 	@echo 
-	
+
 .PHONY: override-hook
 override-hook:
 #### This sets the override template variables for docker-compose.instance.yaml:

--- a/yourls/.env-dist
+++ b/yourls/.env-dist
@@ -41,8 +41,8 @@ YOURLS_MTLS_AUTH=false
 YOURLS_MTLS_AUTHORIZED_CERTS=*.clients.yourls.example.com
 
 # Create a username and password for your YOURLS instance
-YOURLS_USER=username
-YOURLS_PASS=changeme
+YOURLS_USER=
+YOURLS_PASS=
 
 # Database password
 MYSQL_ROOT_PASSWORD=

--- a/yourls/Makefile
+++ b/yourls/Makefile
@@ -8,8 +8,8 @@ config-hook:
 	@${BIN}/reconfigure ${ENV_FILE} YOURLS_INSTANCE=$${instance:-default}
 	@${BIN}/reconfigure_auth ${ENV_FILE} YOURLS
 	@echo
-	@${BIN}/reconfigure_ask ${ENV_FILE} YOURLS_USER "Enter the admin username for your YOURLS instance"
-	@${BIN}/reconfigure_ask ${ENV_FILE} YOURLS_PASS "Enter the password for '"$$(${BIN}/dotenv -f ${ENV_FILE} get YOURLS_USER)"'"
+	@${BIN}/reconfigure_ask ${ENV_FILE} YOURLS_USER "Enter the admin username for your YOURLS instance" -
+	@${BIN}/reconfigure_ask ${ENV_FILE} YOURLS_PASS "Enter the password for '"$$(${BIN}/dotenv -f ${ENV_FILE} get YOURLS_USER)"'" -
 	@echo
 	@${BIN}/reconfigure_password ${ENV_FILE} MYSQL_ROOT_PASSWORD 45
 	@${BIN}/reconfigure_password ${ENV_FILE} YOURLS_COOKIEKEY 45
@@ -35,7 +35,7 @@ shell:
 
 open-hook:
 	${BIN}/open /admin
-	
+
 .PHONY: list-admin-users # List admin users
 list-admin-users:
 # Pull the config.php file from the Docker container

--- a/yourls/Makefile
+++ b/yourls/Makefile
@@ -8,8 +8,8 @@ config-hook:
 	@${BIN}/reconfigure ${ENV_FILE} YOURLS_INSTANCE=$${instance:-default}
 	@${BIN}/reconfigure_auth ${ENV_FILE} YOURLS
 	@echo
-	@${BIN}/reconfigure_ask ${ENV_FILE} YOURLS_USER "Enter the admin username for your YOURLS instance" -
-	@${BIN}/reconfigure_ask ${ENV_FILE} YOURLS_PASS "Enter the password for '"$$(${BIN}/dotenv -f ${ENV_FILE} get YOURLS_USER)"'" -
+	@${BIN}/reconfigure_ask ${ENV_FILE} YOURLS_USER "Enter the admin username for your YOURLS instance"
+	@${BIN}/reconfigure_ask ${ENV_FILE} YOURLS_PASS "Enter the password for '"$$(${BIN}/dotenv -f ${ENV_FILE} get YOURLS_USER)"'"
 	@echo
 	@${BIN}/reconfigure_password ${ENV_FILE} MYSQL_ROOT_PASSWORD 45
 	@${BIN}/reconfigure_password ${ENV_FILE} YOURLS_COOKIEKEY 45


### PR DESCRIPTION
Fixes #292 by removing the default username and password.

In #290 reconfigure_ask was fixed to not allow blanks, so the user is forced to enter a non-blank value.