### PR TITLE
`d routes` (`d make traefik routes`)

### DIFF
--- a/_scripts/d.rymcg.tech
+++ b/_scripts/d.rymcg.tech
@@ -477,7 +477,7 @@ main() {
                 export D_RYMCG_TECH_CLI_ALIAS=${CURRENT_CONTEXT:-d.rymcg.tech}
                 __run_script ssh_expose "${CURRENT_CONTEXT}" $@;;
             routes)
-               __run_script routes;;
+                d.rymcg.tech make traefik routes;;
             config)
                 __make -- config;;
             *)

--- a/_scripts/d.rymcg.tech
+++ b/_scripts/d.rymcg.tech
@@ -394,7 +394,7 @@ __completion() {
     if [[ $# -lt 1 ]]; then
         echo "#### To enable BASH shell completion support for d.rymcg.tech,"
         echo "#### add the following lines into your ~/.bashrc ::"
-        echo "export PATH=\${PATH}:${USER_SCRIPT_RATH}"
+        echo "export PATH=\${PATH}:${USER_SCRIPT_PATH}"
         echo 'eval "$(d.rymcg.tech completion bash)"'
         echo ""
         echo "#### Optional aliases you may wish to uncomment:"

--- a/_scripts/d.rymcg.tech
+++ b/_scripts/d.rymcg.tech
@@ -54,6 +54,7 @@ __help() {
         echo -e "audit\tPrint security audit of running containers"
         echo -e "sshd-config [Var=value ...]\tReconfigure the host SSH daemon of the remote context"
         echo -e "ssh-expose PORT\tExpose a workstation's port to a public server port"
+        echo -e "routes\tPrint the list of Traefik routes"
     ) | expand -t 30
     echo ""
     echo "## Documentation sub-commands:"
@@ -328,7 +329,7 @@ __d.rymcg.tech_completions() {
     if [[ ${COMP_CWORD} == 1 ]]; then
         ## Complete the main command:
         ## d.rymcg.tech <TAB> ...
-        COMMANDS="help create cd make list readme info context new-context tmp-context completion install install-docker status ssh audit sshd-config ssh-expose config"
+        COMMANDS="help create cd make list readme info context new-context tmp-context completion install install-docker status ssh audit sshd-config ssh-expose routes config"
         COMPREPLY=($(compgen -W "${COMMANDS}" "${COMP_WORDS[1]}"))
     elif [[ ${COMP_CWORD} == 2 ]]; then
         ALL_PROJECTS=$(d.rymcg.tech list --raw)
@@ -393,7 +394,7 @@ __completion() {
     if [[ $# -lt 1 ]]; then
         echo "#### To enable BASH shell completion support for d.rymcg.tech,"
         echo "#### add the following lines into your ~/.bashrc ::"
-        echo "export PATH=\${PATH}:${USER_SCRIPT_PATH}"
+        echo "export PATH=\${PATH}:${USER_SCRIPT_RATH}"
         echo 'eval "$(d.rymcg.tech completion bash)"'
         echo ""
         echo "#### Optional aliases you may wish to uncomment:"
@@ -475,6 +476,8 @@ main() {
                 local CURRENT_CONTEXT=$(docker context show)
                 export D_RYMCG_TECH_CLI_ALIAS=${CURRENT_CONTEXT:-d.rymcg.tech}
                 __run_script ssh_expose "${CURRENT_CONTEXT}" $@;;
+            routes)
+               __run_script routes;;
             config)
                 __make -- config;;
             *)

--- a/_scripts/routes
+++ b/_scripts/routes
@@ -12,8 +12,6 @@ get_entrypoint_port() {
     check_var entrypoint_name
     local traefik_env="${ROOT_DIR}/traefik/${ENV_FILE}"
     test -f ${traefik_env} || fault "Could not find traefik env file: ${traefik_env}"
-    debug_var traefik_env
-    set -x
     ${BIN}/dotenv -f "${traefik_env}" get "TRAEFIK_${entrypoint_name^^}_ENTRYPOINT_PORT"
 }
 

--- a/_scripts/routes
+++ b/_scripts/routes
@@ -25,26 +25,29 @@ main() {
             echo "Container_Name Entrypoint URL"
             echo "-------------- ---------- ---"
             docker ps -q | while read -r container_id; do
-                docker inspect "$container_id" | jq -r --arg env_file "$ENV_FILE" '
+                docker inspect "$container_id" | jq -r '
                 .[] | .Name as $name | .Config.Labels as $labels
                 | ($labels | to_entries[]
-                    | select(.key | test("traefik\\.http\\.routers\\..*\\.rule"))
+                    | select(.key | test("traefik\\.http\\.routers\\..*\\.rule") or test("traefik\\.tcp\\.routers\\..*\\.rule"))
                     | .key as $rule_key
                     | .value as $rule_value
                     | ($labels[$rule_key | sub("\\.rule$"; ".entrypoints")] // "unknown") as $entrypoints_value
-                    | ($rule_value | capture("Host\\(`(?<host>[^`]*)`\\)(\\s*&&\\s*Path\\(`(?<path>[^`]*)`\\))?")) as $captured
+                    | ($rule_value | capture("(Host|HostSNI)\\(`(?<host>[^`]*)`\\)(\\s*&&\\s*Path\\(`(?<path>[^`]*)`\\))?")) as $captured
                     | $name[1:] + " " + $entrypoints_value + " " +
                     (
-                        "https://" + $captured.host +
-                        (
-                            if $entrypoints_value == "websecure" then "" else
-                                ":PORT_PLACEHOLDER"
-                            end
-                        ) +
+                        (if $entrypoints_value == "web" then "http://"
+                         elif $entrypoints_value == "web_plain" then "http://"
+                         elif $rule_key | test("traefik\\.http\\.") then "https://"
+                         else $entrypoints_value + "://" end) +
+                        $captured.host +
+                        (if $entrypoints_value == "web" then ""
+                         elif $entrypoints_value == "websecure" then ""
+                         elif $entrypoints_value == "web_plain" then ":PORT_PLACEHOLDER"
+                         else ":PORT_PLACEHOLDER" end) +
                         ($captured.path // "/")
                     )
                 )' | while read -r container_name entrypoint url; do
-                    if [[ "$entrypoint" != "websecure" ]]; then
+                    if [[ "$entrypoint" != "web" && "$entrypoint" != "websecure" ]]; then
                         port=$(get_entrypoint_port "$entrypoint")
                         url="${url//PORT_PLACEHOLDER/$port}"
                     fi
@@ -60,7 +63,6 @@ main() {
         >&2 echo "$line"
         cat
     } | less -FSX
-    
 }
 
 main

--- a/_scripts/routes
+++ b/_scripts/routes
@@ -12,16 +12,49 @@ get_entrypoint_port() {
     check_var entrypoint_name
     local traefik_env="${ROOT_DIR}/traefik/${ENV_FILE}"
     test -f ${traefik_env} || fault "Could not find traefik env file: ${traefik_env}"
+    debug_var traefik_env
+    set -x
     ${BIN}/dotenv -f "${traefik_env}" get "TRAEFIK_${entrypoint_name^^}_ENTRYPOINT_PORT"
 }
 
+# Function to get layer 4 routes if enabled
+get_layer_4_routes() {
+    cd ${ROOT_DIR}
+    local traefik_env="${ROOT_DIR}/traefik/${ENV_FILE}"
+    test -f ${traefik_env} || fault "Could not find traefik env file: ${traefik_env}"
+    debug_var traefik_env
+    set -x
+    local layer_4_enabled=$(${BIN}/dotenv -f "${traefik_env}" get "TRAEFIK_LAYER_4_TCP_UDP_PROXY_ENABLED")
+    if [[ "$layer_4_enabled" == "true" ]]; then
+        ${BIN}/dotenv -f "${traefik_env}" get "TRAEFIK_LAYER_4_TCP_UDP_PROXY_ROUTES"
+    else
+        echo ""
+    fi
+}
+
+# Function to get layer 7 routes if enabled
+get_layer_7_routes() {
+    cd ${ROOT_DIR}
+    local traefik_env="${ROOT_DIR}/traefik/${ENV_FILE}"
+    test -f ${traefik_env} || fault "Could not find traefik env file: ${traefik_env}"
+    debug_var traefik_env
+    set -x
+    local layer_7_enabled=$(${BIN}/dotenv -f "${traefik_env}" get "TRAEFIK_LAYER_7_TLS_PROXY_ENABLED")
+    if [[ "$layer_7_enabled" == "true" ]]; then
+        ${BIN}/dotenv -f "${traefik_env}" get "TRAEFIK_LAYER_7_TLS_PROXY_ROUTES"
+    else
+        echo ""
+    fi
+}
+
 main() {
-    # Print list of Traefik container routes
+    
+# Print list of Traefik container routes
     {
         # Generate formatted output
         {
-            echo "Container_Name Entrypoint URL"
-            echo "-------------- ---------- ---"
+            echo "Service Entrypoint URL Destination"
+            echo "-------------- ---------- --- ----------"
             docker ps -q | while read -r container_id; do
                 docker inspect "$container_id" | jq -r '
                 .[] | .Name as $name | .Config.Labels as $labels
@@ -49,9 +82,37 @@ main() {
                         port=$(get_entrypoint_port "$entrypoint")
                         url="${url//PORT_PLACEHOLDER/$port}"
                     fi
-                    echo "$container_name $entrypoint $url"
+                    echo "$container_name $entrypoint $url -"
                 done
             done
+
+            # Print layer 4 routes if enabled
+            layer_4_routes=$(get_layer_4_routes)
+            if [[ -n "$layer_4_routes" ]]; then
+                IFS=',' read -ra routes <<< "$layer_4_routes"
+                declare -A seen_routes
+                for route in "${routes[@]}"; do
+                    IFS=':' read -r protocol ip_address port _ <<< "$route"
+                    if [[ -z "${seen_routes[$route]}" ]]; then
+                        echo "- layer-4 ${protocol}://${ip_address}:${port} ${ip_address}:${port}"
+                        seen_routes[$route]=1
+                    fi
+                done
+            fi
+
+            # Print layer 7 routes if enabled
+            layer_7_routes=$(get_layer_7_routes)
+            if [[ -n "$layer_7_routes" ]]; then
+                IFS=',' read -ra routes <<< "$layer_7_routes"
+                declare -A seen_routes
+                for route in "${routes[@]}"; do
+                    IFS=':' read -r domain ip_address port _ <<< "$route"
+                    if [[ -z "${seen_routes[$route]}" ]]; then
+                        echo "- layer-7 https://${domain} ${ip_address}:${port}"
+                        seen_routes[$route]=1
+                    fi
+                done
+            fi
         } | column -t
     } | {
         # Split output to stderr and stdout

--- a/_scripts/routes
+++ b/_scripts/routes
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+BIN=$(realpath $(dirname ${BASH_SOURCE}))
+source ${BIN}/funcs.sh
+check_var ENV_FILE ROOT_DIR
+set -eo pipefail
+
+# Function to get the port number for a given entrypoint from the .env file
+get_entrypoint_port() {
+    cd ${ROOT_DIR}
+    local entrypoint_name="$1"
+    check_var entrypoint_name
+    local traefik_env="${ROOT_DIR}/traefik/${ENV_FILE}"
+    test -f ${traefik_env} || fault "Could not find traefik env file: ${traefik_env}"
+    debug_var traefik_env
+    set -x
+    ${BIN}/dotenv -f "${traefik_env}" get "TRAEFIK_${entrypoint_name^^}_ENTRYPOINT_PORT"
+}
+
+main() {
+    # Print list of Traefik container routes
+    {
+        # Generate formatted output
+        {
+            echo "Container_Name Entrypoint URL"
+            echo "-------------- ---------- ---"
+            docker ps -q | while read -r container_id; do
+                docker inspect "$container_id" | jq -r --arg env_file "$ENV_FILE" '
+                .[] | .Name as $name | .Config.Labels as $labels
+                | ($labels | to_entries[]
+                    | select(.key | test("traefik\\.http\\.routers\\..*\\.rule"))
+                    | .key as $rule_key
+                    | .value as $rule_value
+                    | ($labels[$rule_key | sub("\\.rule$"; ".entrypoints")] // "unknown") as $entrypoints_value
+                    | ($rule_value | capture("Host\\(`(?<host>[^`]*)`\\)(\\s*&&\\s*Path\\(`(?<path>[^`]*)`\\))?")) as $captured
+                    | $name[1:] + " " + $entrypoints_value + " " +
+                    (
+                        "https://" + $captured.host +
+                        (
+                            if $entrypoints_value == "websecure" then "" else
+                                ":PORT_PLACEHOLDER"
+                            end
+                        ) +
+                        ($captured.path // "/")
+                    )
+                )' | while read -r container_name entrypoint url; do
+                    if [[ "$entrypoint" != "websecure" ]]; then
+                        port=$(get_entrypoint_port "$entrypoint")
+                        url="${url//PORT_PLACEHOLDER/$port}"
+                    fi
+                    echo "$container_name $entrypoint $url"
+                done
+            done
+        } | column -t
+    } | {
+        # Split output to stderr and stdout
+        read -r header
+        read -r line
+        >&2 echo "$header"
+        >&2 echo "$line"
+        cat
+    } | less -FSX
+    
+}
+
+main

--- a/_scripts/routes
+++ b/_scripts/routes
@@ -12,8 +12,6 @@ get_entrypoint_port() {
     check_var entrypoint_name
     local traefik_env="${ROOT_DIR}/traefik/${ENV_FILE}"
     test -f ${traefik_env} || fault "Could not find traefik env file: ${traefik_env}"
-    debug_var traefik_env
-    set -x
     ${BIN}/dotenv -f "${traefik_env}" get "TRAEFIK_${entrypoint_name^^}_ENTRYPOINT_PORT"
 }
 
@@ -22,8 +20,6 @@ get_layer_4_routes() {
     cd ${ROOT_DIR}
     local traefik_env="${ROOT_DIR}/traefik/${ENV_FILE}"
     test -f ${traefik_env} || fault "Could not find traefik env file: ${traefik_env}"
-    debug_var traefik_env
-    set -x
     local layer_4_enabled=$(${BIN}/dotenv -f "${traefik_env}" get "TRAEFIK_LAYER_4_TCP_UDP_PROXY_ENABLED")
     if [[ "$layer_4_enabled" == "true" ]]; then
         ${BIN}/dotenv -f "${traefik_env}" get "TRAEFIK_LAYER_4_TCP_UDP_PROXY_ROUTES"
@@ -37,8 +33,6 @@ get_layer_7_routes() {
     cd ${ROOT_DIR}
     local traefik_env="${ROOT_DIR}/traefik/${ENV_FILE}"
     test -f ${traefik_env} || fault "Could not find traefik env file: ${traefik_env}"
-    debug_var traefik_env
-    set -x
     local layer_7_enabled=$(${BIN}/dotenv -f "${traefik_env}" get "TRAEFIK_LAYER_7_TLS_PROXY_ENABLED")
     if [[ "$layer_7_enabled" == "true" ]]; then
         ${BIN}/dotenv -f "${traefik_env}" get "TRAEFIK_LAYER_7_TLS_PROXY_ROUTES"

--- a/icecast/Makefile
+++ b/icecast/Makefile
@@ -19,4 +19,4 @@ shell:
 
 .PHONY: override-hook
 override-hook:
-	@${BIN}/docker_compose_override ${ENV_FILE} ICECAST_ALLOW_DIRECT_MAP_PORT ICECAST_DIRECT_MAP_PORT
+	@${BIN}/docker_compose_override ${ENV_FILE} icecast_allow_direct_map_port=ICECAST_ALLOW_DIRECT_MAP_PORT icecast_direct_map_port=ICECAST_DIRECT_MAP_PORT

--- a/traefik/Makefile
+++ b/traefik/Makefile
@@ -95,3 +95,7 @@ sentry:
 .PHONY: sentry-callback
 sentry-callback:
 	@${BIN}/reconfigure_header_authorization ${ENV_FILE} list-callback-urls
+
+.PHONY: routes # List of all the application routes
+routes:
+	@ENV_FILE=${ENV_FILE} ${BIN}/routes


### PR DESCRIPTION
This adds a make target to list the the traefik routes.

Fixes #337 

```
$ d routes
Service                    Entrypoint  URL                                                                 Destination
--------------             ----------  ---                                                                 ----------
whoami-whoami-1            web         http://whoami.delorean-dev.nogn.rymcg.tech/                         -
mosquitto-mosquitto-1      mqtt        mqtt://mqtt.delorean-dev.nogn.rymcg.tech:8883/                      -
forgejo-forgejo-1          websecure   https://git.delorean-dev.forwarding.network/logout                  -
forgejo-forgejo-1          websecure   https://git.delorean-dev.forwarding.network/logout2                 -
forgejo-forgejo-1          websecure   https://git.delorean-dev.forwarding.network/                        -
forgejo-forgejo-1          ssh         ssh://*:2222/                                                       -
icecast-icecast-1          websecure   https://icecast.delorean-dev.nogn.rymcg.tech/                       -
vaultwarden-vaultwarden-1  websecure   https://vaultwarden.delorean-dev.nogn.rymcg.tech/notifications/hub  -
vaultwarden-vaultwarden-1  websecure   https://vaultwarden.delorean-dev.nogn.rymcg.tech/                   -
-                          layer-4     ssh://10.13.16.2:2222                                               10.13.16.2:2222
-                          layer-7     https://asdf.delorean-dev.nogn.rymcg.tech                           10.13.16.2:443
```