### PR TITLE
Traefik tls entrypoint

### DIFF
--- a/traefik/.env-dist
+++ b/traefik/.env-dist
@@ -201,9 +201,9 @@ TRAEFIK_RTMP_PROXY_PROTOCOL_TRUSTED_IPS=
 TRAEFIK_RTMP_ENTRYPOINT_PROXY_PROTOCOL_TRUSTED_IPS=
 
 ## User custom entrypoints (tcp and/or udp):
-### TRAEFIK_CUSTOM_ENTRYPOINTS is a comma separated list of 5-tuples:
-####  entrypoint_name:listen_host:listen_port:protocol:trusted_proxies,...
-### TRAEFIK_CUSTOM_ENTRYPOINTS=telnet:0.0.0.0:23:tcp:,dns:10.13.16.1:53:udp:127.0.0.1/32
+### TRAEFIK_CUSTOM_ENTRYPOINTS is a comma separated list of 6-tuples:
+####  entrypoint_name:listen_host:listen_port:protocol:trusted_proxies:use_https,...
+### TRAEFIK_CUSTOM_ENTRYPOINTS=telnet:0.0.0.0:23:tcp::false,dns:10.13.16.1:53:udp:127.0.0.1/32:false
 ### trusted_proxies is a dash separated list of trusted upstream proxies CIDR.
 TRAEFIK_CUSTOM_ENTRYPOINTS=
 

--- a/traefik/config/traefik.yml
+++ b/traefik/config/traefik.yml
@@ -120,9 +120,35 @@ entryPoints:
   #@ if not len(custom_entrypoint):
   #@ continue
   #@ end
-  #@ entrypoint,listen_host,listen_port,protocol,trusted_nets = custom_entrypoint.split(":")
+  #@ entrypoint,listen_host,listen_port,protocol,trusted_nets,use_https = custom_entrypoint.split(":")
   (@= entrypoint @):
     address: #@ listen_host + ":" + listen_port + "/" + protocol
+    #@ if use_https == "true":
+    http:
+      tls:
+        #@ if data.values.acme_enabled == "true":
+        certResolver: #@ data.values.acme_cert_resolver
+        domains:
+          #@ for domain in json.decode(data.values.acme_cert_domains):
+          - main: #@ domain[0]
+            sans:
+              #@ for secondary in domain[1]:
+              - #@ secondary
+              #@ end
+          #@ end
+        #@ end
+      middlewares:
+        - strip-headers@file
+        #@ if len(data.values.error_handler_403_service):
+        - traefik-websecure-error-handler-403@file
+        #@ end
+        #@ if len(data.values.error_handler_404_service):
+        - traefik-websecure-error-handler-404@file
+        #@ end
+        #@ if len(data.values.error_handler_500_service):
+        - traefik-websecure-error-handler-500@file
+        #@ end
+    #@ end
     #@ if len(trusted_nets):
     proxyProtocol:
       trustedIPs:

--- a/traefik/setup.sh
+++ b/traefik/setup.sh
@@ -200,8 +200,8 @@ get_enabled_entrypoints() {
 list_enabled_entrypoints() {
     readarray -t entrypoints < <(get_enabled_entrypoints)
     (
-        echo -e "Entrypoint\tListen_address\tListen_port\tProtocol\tUpstream_proxy"
-        echo -e "----------\t--------------\t-----------\t--------\t--------------"
+        echo -e "Entrypoint\tListen_address\tListen_port\tProtocol\tUpstream_proxy\tUse_Https"
+        echo -e "----------\t--------------\t-----------\t--------\t--------------\t-------"
         (
             for e in "${entrypoints[@]}"; do
                 local ENTRYPOINT="$(echo "${e}" | tr '[:lower:]' '[:upper:]')"
@@ -644,7 +644,7 @@ list_custom_entrypoints() {
         #echo "## No custom entrypoints defined." >/dev/stderr
         return
     fi
-    (echo "${ENTRYPOINTS}" | tr ',' '\n' | sed 's/:/\t/g' | sort -u) | column -t
+    (echo "${ENTRYPOINTS}" | tr ',' '\n' | sed 's/::/:-:/g' | sed 's/:/\t/g' | sort -u) | column -t
 }
 
 manage_custom_entrypoints() {
@@ -733,11 +733,11 @@ add_custom_entrypoint() {
         0) TRUSTED_NETS=;;
         1) TRUSTED_NETS=$(ask_echo "Enter the comma separated list of trusted upstream proxy servers (CIDR)" 10.13.16.1/32);;
     esac
-
+    USE_HTTPS=$(choose "Does this entrypoint use HTTPS?" "true" "false")
     if [[ -n "${CUSTOM_ENTRYPOINTS}" ]]; then
         CUSTOM_ENTRYPOINTS="${CUSTOM_ENTRYPOINTS},"
     fi
-    CUSTOM_ENTRYPOINTS="${CUSTOM_ENTRYPOINTS}${ENTRYPOINT}:${ENTRYPOINT_IP_ADDRESS}:${ENTRYPOINT_PORT}:${PROTOCOL}:${TRUSTED_NETS}"
+    CUSTOM_ENTRYPOINTS="${CUSTOM_ENTRYPOINTS}${ENTRYPOINT}:${ENTRYPOINT_IP_ADDRESS}:${ENTRYPOINT_PORT}:${PROTOCOL}:${TRUSTED_NETS}:${USE_HTTPS}"
     ${BIN}/reconfigure ${ENV_FILE} "TRAEFIK_CUSTOM_ENTRYPOINTS=${CUSTOM_ENTRYPOINTS}"
 }
 


### PR DESCRIPTION
Fixes #349 

This adds a 6th item to the CUSTOM_ENTRYPOINTS tuple, so this is a breaking change and existing entrypoints will need to be manually added to add `:false` onto the end.