### PR TITLE
Security 29

### DIFF
--- a/homepage/homepage/package.json
+++ b/homepage/homepage/package.json
@@ -4,6 +4,6 @@
 		"child_process": "^1.0.2",
 		"express": "^4.20.0",
 		"http": "0.0.1-security",
-		"ip": "^2.0.1"
+		"ip": "^2.0.2"
 	}
 }

--- a/homepage/homepage/pnpm-lock.yaml
+++ b/homepage/homepage/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 0.0.1-security
         version: 0.0.1-security
       ip:
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: ^2.0.2
+        version: 2.0.2
 
 packages:
 
@@ -164,8 +164,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip@2.0.1:
-    resolution: {integrity: sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==}
+  ip@2.0.2:
+    resolution: {integrity: sha512-AEHYbO4DUrbor46XVfvorW2xkSt7wu/VPRn/YM6Peaabusm8K7rCXZ+m2enkjYvMJB/gR3bCPBO6WisolmQ1cg==}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -465,7 +465,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip@2.0.1: {}
+  ip@2.0.2: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
This is my attempt to fix dependabot's [security alert #29](https://github.com/EnigmaCurry/d.rymcg.tech/security/dependabot/29).

I changed every instance of `ip 2.0.1` to `ip.2.0.2` (and got the sha512 by downloading the package), but it throws error on install:
```
> [homepage 5/5] RUN cd /app/reloader && npm install:
6.223 npm error code ETARGET
6.223 npm error notarget No matching version found for ip@^2.0.2.
6.223 npm error notarget In most cases you or one of your dependencies are requesting
6.223 npm error notarget a package version that doesn't exist.
```
 