### PR TITLE
Uncomment ARCHIVEBOX_API_GATEWAY_CONTEXT in `.env-dist` 

### DIFF
--- a/archivebox/.env-dist
+++ b/archivebox/.env-dist
@@ -36,8 +36,7 @@ ARCHIVEBOX_EMAIL=admin@localhost
 API_LOG_LEVEL=WARN
 
 ## Build the API gateway from an arbitrary (git) source or directory:
-## ARCHIVEBOX_API_GATEWAY_CONTEXT=https://github.com/EnigmaCurry/archivebox-api-gateway.git
-
+ARCHIVEBOX_API_GATEWAY_CONTEXT=https://github.com/EnigmaCurry/archivebox-api-gateway.git
 
 # Filter access by IP address source range (CIDR):
 ##Disallow all access: 0.0.0.0/32


### PR DESCRIPTION
Uncomment ARCHIVEBOX_API_GATEWAY_CONTEXT in `.env-dist` with enigmacurry's repo as default value (which is the default value in `docker-compose.yaml` anyway, and because the repo was just updated to work correctly), because while it was commented, if a user uncommented it to use their own repo, `make config` would prompt them to delete the env var because it's not in `.env-dist`.