### PR TITLE
Homepage vols

### DIFF
--- a/backrest/.env-dist
+++ b/backrest/.env-dist
@@ -1,5 +1,5 @@
-# The docker image to use:
-BACKREST_IMAGE=garethgeorge/backrest:v1.6
+# The docker image to use (https://hub.docker.com/r/garethgeorge/backrest/tags):
+BACKREST_IMAGE=garethgeorge/backrest:v1.7
 
 # The domain name for the backrest service:
 BACKREST_TRAEFIK_HOST=backrest.example.com

--- a/backrest/docker-compose.yaml
+++ b/backrest/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   backrest:
-    image: garethgeorge/backrest:latest
+    image: ${BACKREST_IMAGE}
     volumes:
       - data:/data
       - config:/config

--- a/forgejo/.env-dist
+++ b/forgejo/.env-dist
@@ -1,6 +1,6 @@
 FORGEJO_TRAEFIK_HOST=git.example.com
 # The Forgejo image to use (https://codeberg.org/forgejo/forgejo/tags)
-FORGEJO_IMAGE=codeberg.org/forgejo/forgejo:10.0.1-rootless
+FORGEJO_IMAGE=codeberg.org/forgejo/forgejo:10.0.3-rootless
 FORGEJO_SSH_PORT=2222
 
 # The name of this instance. If there is only one instance, use 'default'.

--- a/homepage/.env-dist
+++ b/homepage/.env-dist
@@ -6,7 +6,7 @@ HOMEPAGE_TRAEFIK_HOST=homepage.example.com
 HOMEPAGE_WEBHOOK_HOST=homepage-webhook.example.com
 
 # The tag for the Docker image
-HOMEPAGE_VERSION=v1.0.3
+HOMEPAGE_VERSION=v1.1.1
 
 # The name of this instance. If there is only one instance, use 'default'.
 HOMEPAGE_INSTANCE=

--- a/homepage/.env-dist
+++ b/homepage/.env-dist
@@ -6,7 +6,7 @@ HOMEPAGE_TRAEFIK_HOST=homepage.example.com
 HOMEPAGE_WEBHOOK_HOST=homepage-webhook.example.com
 
 # The tag for the Docker image
-HOMEPAGE_VERSION=v0.10.9
+HOMEPAGE_VERSION=v1.0.3
 
 # The name of this instance. If there is only one instance, use 'default'.
 HOMEPAGE_INSTANCE=
@@ -81,6 +81,13 @@ HOMEPAGE_TEMPLATE_REPO_SYNC_ON_START=false
 ## If HOMEPAGE_PUBLIC_HTTPS_PORT is blank, Homepage will use the public https port
 ## configured in the root .env file for this Docker context.
 HOMEPAGE_PUBLIC_HTTPS_PORT=
+
+## HOMEPAGE_ALLOWED_HOSTS helps prevent certain kinds of attacks when retrieving
+## data from the homepage API proxy. The value is a comma-separated (no spaces)
+## list of allowed hosts (sometimes with the port) that can host your homepage
+## install. For more information about where / how to set the variable, see
+## https://gethomepage.dev/installation/#homepage_allowed_hosts .
+HOMEPAGE_ALLOWED_HOSTS=
 
 # To mount extra paths on the host into volumes in the Homepage container, add a
 # comma-separated list of volume mappings. For example:

--- a/homepage/docker-compose.instance.yaml
+++ b/homepage/docker-compose.instance.yaml
@@ -52,7 +52,7 @@ services:
       #@ end
       - config:/app/public/images #! (optional) So Homepage can use images from config dir
       #@ for vol in volume_mounts:
-      - (@= vol @)
+      - (@= vol @):ro
       #@ end  
     labels:
       - "backup-volume.stop-during-backup=true"

--- a/homepage/docker-compose.yaml
+++ b/homepage/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
       - HOMEPAGE_TEMPLATE_REPO
       - HOMEPAGE_TEMPLATE_REPO_SYNC_ON_START
       - HOMEPAGE_AUTO_CONFIG
+      - HOMEPAGE_ALLOWED_HOSTS=${HOMEPAGE_ALLOWED_HOSTS:-${HOMEPAGE_TRAEFIK_HOST}}
     # All volumes are defined in the template: docker-compose.instance.yaml
     volumes: []
     # All labels are defined in the template: docker-compose.instance.yaml

--- a/immich/.env-dist
+++ b/immich/.env-dist
@@ -1,10 +1,10 @@
 # The docker image to use for Immich Server (https://github.com/immich-app/immich/pkgs/container/immich-server):
-IMMICH_IMAGE=ghcr.io/immich-app/immich-server:v1.129.0
+IMMICH_IMAGE=ghcr.io/immich-app/immich-server:v1.130.3
 # The docker image to use for Immich Machine Learning (https://github.com/immich-app/immich/pkgs/container/immich-machine-learning):
 # Do *not* include the trailing hardware identifier in the tag (e.g.,
 # use "v1.115.0" instead of "v1.115.0-cuda") - the hardware identifier is
 # automatically added based on the Hardware Acceleration you select.
-IMMICH_ML_IMAGE=ghcr.io/immich-app/immich-machine-learning:v1.129.0
+IMMICH_ML_IMAGE=ghcr.io/immich-app/immich-machine-learning:v1.130.3
 # The docker image to use for Postgres ():
 IMMICH_POSTRGES_IMAGE=docker.io/tensorchord/pgvecto-rs
 

--- a/ntfy-sh/Makefile
+++ b/ntfy-sh/Makefile
@@ -42,7 +42,7 @@ shell:
 user:
 	@NTFY_PASSWORD=$$(openssl rand -base64 25) && read -e -p "Enter the username to create: " NTFY_USERNAME && docker compose --env-file=${ENV_FILE} exec -e NTFY_PASSWORD=$${NTFY_PASSWORD} ntfy ntfy user add $${NTFY_USERNAME} && echo "Username: $${NTFY_USERNAME}" && echo "Password: $${NTFY_PASSWORD}"
 
-.PHONY: access
+.PHONY: access # Show all users and their granted access
 access:
 	docker compose --env-file=${ENV_FILE} exec -it ntfy ntfy access
 

--- a/ntfy-sh/Makefile
+++ b/ntfy-sh/Makefile
@@ -38,7 +38,7 @@ override-hook:
 shell:
 	@make --no-print-directory docker-compose-shell SERVICE=ntfy
 
-.PHONY: user
+.PHONY: user # Create a user
 user:
 	@NTFY_PASSWORD=$$(openssl rand -base64 25) && read -e -p "Enter the username to create: " NTFY_USERNAME && docker compose --env-file=${ENV_FILE} exec -e NTFY_PASSWORD=$${NTFY_PASSWORD} ntfy ntfy user add $${NTFY_USERNAME} && echo "Username: $${NTFY_USERNAME}" && echo "Password: $${NTFY_PASSWORD}"
 

--- a/peertube/.env-dist
+++ b/peertube/.env-dist
@@ -1,5 +1,5 @@
 # The docker image to use (https://hub.docker.com/r/chocobozzz/peertube/tags):
-PEERTUBE_IMAGE=chocobozzz/peertube:v7.0.0-bookworm
+PEERTUBE_IMAGE=chocobozzz/peertube:v7.1.0-bookworm
 # The Postgres image to use:
 PEERTUBE_POSTGRES_IMAGE=postgres:16-alpine
 

--- a/searxng/.env-dist
+++ b/searxng/.env-dist
@@ -1,5 +1,5 @@
 # The docker image to use for SearXNG (https://hub.docker.com/r/searxng/searxng/tags):
-SEARXNG_IMAGE=docker.io/searxng/searxng:2025.3.16-84636ef49
+SEARXNG_IMAGE=docker.io/searxng/searxng:2025.3.30-7b4612e86
 # The docker image to use for Valkey (Redis) (https://hub.docker.com/r/valkey/valkey):
 SEARXNG_REDIS_IMAGE=docker.io/valkey/valkey:8.0-alpine
 

--- a/tesseract/.env-dist
+++ b/tesseract/.env-dist
@@ -1,5 +1,5 @@
 # The docker image to use:
-TESSERACT_IMAGE=ghcr.io/asimons04/tesseract:v1.4.29
+TESSERACT_IMAGE=ghcr.io/asimons04/tesseract:v1.4.32
 
 # The domain name for the tesseract service:
 TESSERACT_TRAEFIK_HOST=tesseract.example.com

--- a/triliumnext-notes/.env-dist
+++ b/triliumnext-notes/.env-dist
@@ -1,5 +1,5 @@
 # The docker image to use (https://hub.docker.com/r/triliumnext/notes/tags):
-TRILIUMNEXT_NOTES_IMAGE=triliumnext/notes:v0.91.5
+TRILIUMNEXT_NOTES_IMAGE=triliumnext/notes:v0.92.4
 
 # The domain name for the TriliumNext Notes service:
 TRILIUMNEXT_NOTES_TRAEFIK_HOST=triliumnext-notes.example.com


### PR DESCRIPTION
Change volume mount to :ro, apparently required for homepage to use docker sockets as mounted volumes (which is a good thing) - I think this is new to a Homepage upgrade.