### PR TITLE
remove commentario postfix-relay

### DIFF
--- a/commentario/README.md
+++ b/commentario/README.md
@@ -3,12 +3,6 @@
 [Commentario](https://gitlab.com/comentario/comentario) is a comment
 platform for your websites.
 
-## Deploy postfix-relay
-
-To support outgoing email, install [postfix-relay](../postfix-relay)
-on the same Docker server. Commentario will connect to the same Docker
-network: `postfix-relay_default`.
-
 ## Config
 
 ```

--- a/commentario/docker-compose.yaml
+++ b/commentario/docker-compose.yaml
@@ -1,6 +1,6 @@
-networks:
-  postfix-relay_default:
-    external: true
+#networks:
+#  postfix-relay_default:
+#    external: true
 
 services:
   config:
@@ -39,7 +39,7 @@ services:
     restart: unless-stopped
     networks:
       - default
-      - postfix-relay_default
+      #- postfix-relay_default
     ## For debug logging, ad -vv
     #command: ["--host=0.0.0.0", "--port=80", "-vv"]
     command: ["--host=0.0.0.0", "--port=80", "-v"]


### PR DESCRIPTION
Might add the postfix-relay back later, but its not working right now so I'm removing it. Just put the direct SMTP config instead.