### PR TITLE
Variablize service versions

### DIFF
--- a/jitsi-meet/.env-dist
+++ b/jitsi-meet/.env-dist
@@ -3,13 +3,7 @@
 ## Find the latest github release at https://github.com/jitsi/jitsi-meet/releases
 ## For example https://github.com/jitsi/jitsi-meet/releases/tag/stable%2Fjitsi-meet_8719 appears on GH as 2.0.8719
 ## So the image tag name would just be stable-8719
-<<<<<<< Updated upstream
-JITSIMEET_VERSION=stable-10184
-||||||| Stash base
-JITSI_WEB_VERSION=stable-9955
-=======
 JITSI_WEB_VERSION=stable-10185
->>>>>>> Stashed changes
 
 JITSIMEET_TRAEFIK_HOST=meet.d.example.com
 

--- a/jitsi-meet/.env-dist
+++ b/jitsi-meet/.env-dist
@@ -3,7 +3,13 @@
 ## Find the latest github release at https://github.com/jitsi/jitsi-meet/releases
 ## For example https://github.com/jitsi/jitsi-meet/releases/tag/stable%2Fjitsi-meet_8719 appears on GH as 2.0.8719
 ## So the image tag name would just be stable-8719
+<<<<<<< Updated upstream
 JITSIMEET_VERSION=stable-10184
+||||||| Stash base
+JITSI_WEB_VERSION=stable-9955
+=======
+JITSI_WEB_VERSION=stable-10185
+>>>>>>> Stashed changes
 
 JITSIMEET_TRAEFIK_HOST=meet.d.example.com
 

--- a/jitsi-meet/docker-compose.yaml
+++ b/jitsi-meet/docker-compose.yaml
@@ -14,13 +14,7 @@ networks:
 services:
     # Frontend
     web:
-<<<<<<< Updated upstream
-        image: jitsi/web:${JITSIMEET_VERSION}
-||||||| Stash base
-        image: jitsi/web:${JITSI_WEB_VERSION}
-=======
         image: jitsi/web:stable-${JITSI_WEB_VERSION}
->>>>>>> Stashed changes
         restart: ${RESTART_POLICY}
         volumes:
             - web_config:/config:Z
@@ -206,13 +200,7 @@ services:
 
     # XMPP server
     prosody:
-<<<<<<< Updated upstream
-        image: jitsi/prosody:${JITSIMEET_VERSION}
-||||||| Stash base
-        image: jitsi/prosody:stable-6865
-=======
         image: jitsi/prosody:stable-${JITSI_WEB_VERSION}
->>>>>>> Stashed changes
         restart: ${RESTART_POLICY}
         expose:
             - '5222'
@@ -361,13 +349,7 @@ services:
 
     # Focus component
     jicofo:
-<<<<<<< Updated upstream
-        image: jitsi/jicofo:${JITSIMEET_VERSION}
-||||||| Stash base
-        image: jitsi/jicofo:stable-6865
-=======
         image: jitsi/jicofo:stable-${JITSI_WEB_VERSION}
->>>>>>> Stashed changes
         restart: ${RESTART_POLICY}
         volumes:
             - jicofo:/config:Z
@@ -456,13 +438,7 @@ services:
     
     # Video bridge
     jvb:
-<<<<<<< Updated upstream
-        image: jitsi/jvb:${JITSIMEET_VERSION}
-||||||| Stash base
-        image: jitsi/jvb:stable-6865
-=======
         image: jitsi/jvb:stable-${JITSI_WEB_VERSION}
->>>>>>> Stashed changes
         restart: ${RESTART_POLICY}
         ports:
             - '${JVB_PORT}:${JVB_PORT}/udp'

--- a/jitsi-meet/docker-compose.yaml
+++ b/jitsi-meet/docker-compose.yaml
@@ -14,7 +14,7 @@ networks:
 services:
     # Frontend
     web:
-        image: jitsi/web:stable-${JITSI_WEB_VERSION}
+        image: jitsi/web:${JITSI_WEB_VERSION}
         restart: ${RESTART_POLICY}
         volumes:
             - web_config:/config:Z
@@ -200,7 +200,7 @@ services:
 
     # XMPP server
     prosody:
-        image: jitsi/prosody:stable-${JITSI_WEB_VERSION}
+        image: jitsi/prosody:${JITSI_WEB_VERSION}
         restart: ${RESTART_POLICY}
         expose:
             - '5222'
@@ -349,7 +349,7 @@ services:
 
     # Focus component
     jicofo:
-        image: jitsi/jicofo:stable-${JITSI_WEB_VERSION}
+        image: jitsi/jicofo:${JITSI_WEB_VERSION}
         restart: ${RESTART_POLICY}
         volumes:
             - jicofo:/config:Z
@@ -438,7 +438,7 @@ services:
     
     # Video bridge
     jvb:
-        image: jitsi/jvb:stable-${JITSI_WEB_VERSION}
+        image: jitsi/jvb:${JITSI_WEB_VERSION}
         restart: ${RESTART_POLICY}
         ports:
             - '${JVB_PORT}:${JVB_PORT}/udp'

--- a/jitsi-meet/docker-compose.yaml
+++ b/jitsi-meet/docker-compose.yaml
@@ -14,7 +14,13 @@ networks:
 services:
     # Frontend
     web:
+<<<<<<< Updated upstream
         image: jitsi/web:${JITSIMEET_VERSION}
+||||||| Stash base
+        image: jitsi/web:${JITSI_WEB_VERSION}
+=======
+        image: jitsi/web:stable-${JITSI_WEB_VERSION}
+>>>>>>> Stashed changes
         restart: ${RESTART_POLICY}
         volumes:
             - web_config:/config:Z
@@ -200,7 +206,13 @@ services:
 
     # XMPP server
     prosody:
+<<<<<<< Updated upstream
         image: jitsi/prosody:${JITSIMEET_VERSION}
+||||||| Stash base
+        image: jitsi/prosody:stable-6865
+=======
+        image: jitsi/prosody:stable-${JITSI_WEB_VERSION}
+>>>>>>> Stashed changes
         restart: ${RESTART_POLICY}
         expose:
             - '5222'
@@ -349,7 +361,13 @@ services:
 
     # Focus component
     jicofo:
+<<<<<<< Updated upstream
         image: jitsi/jicofo:${JITSIMEET_VERSION}
+||||||| Stash base
+        image: jitsi/jicofo:stable-6865
+=======
+        image: jitsi/jicofo:stable-${JITSI_WEB_VERSION}
+>>>>>>> Stashed changes
         restart: ${RESTART_POLICY}
         volumes:
             - jicofo:/config:Z
@@ -438,7 +456,13 @@ services:
     
     # Video bridge
     jvb:
+<<<<<<< Updated upstream
         image: jitsi/jvb:${JITSIMEET_VERSION}
+||||||| Stash base
+        image: jitsi/jvb:stable-6865
+=======
+        image: jitsi/jvb:stable-${JITSI_WEB_VERSION}
+>>>>>>> Stashed changes
         restart: ${RESTART_POLICY}
         ports:
             - '${JVB_PORT}:${JVB_PORT}/udp'


### PR DESCRIPTION
It's possible that we'll be removing jitsi from d.ry, but as longs as it's still here, I had this change from when we were last trying to make it work: variablize the service versions.