### PR TITLE
Update `make shell` to include previous functionality: `service=xxx`

### DIFF
--- a/archivebox/Makefile
+++ b/archivebox/Makefile
@@ -99,4 +99,8 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'archivebox' 'public-api-gateway' --default 'archivebox'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'archivebox' 'public-api-gateway' --default 'archivebox'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/commentario/Makefile
+++ b/commentario/Makefile
@@ -35,7 +35,11 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@make --no-print-directory docker-compose-shell SERVICE=commentario
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'commentario' 'postgres' --default 'commentario'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;
 
 .PHONY: psql
 psql:

--- a/coturn/Makefile
+++ b/coturn/Makefile
@@ -30,7 +30,11 @@ override-hook:
 
 .PHONY: shell # Enter container shell
 shell:
-	@make --no-print-directory docker-compose-shell SERVICE=coturn
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'caddy' 'coturn' --default 'coturn'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;
 
 .PHONY: credentials # Get ephemeral TURN credentials
 credentials:

--- a/drawio/Makefile
+++ b/drawio/Makefile
@@ -25,4 +25,8 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'plantuml-server' 'image-export' 'drawio' --default 'drawio'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'plantuml-server' 'image-export' 'drawio' --default 'drawio'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/github-actions-runner/Makefile
+++ b/github-actions-runner/Makefile
@@ -9,4 +9,8 @@ config-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'docker' 'runner' --default 'docker'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'docker' 'runner' --default 'docker'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/immich/Makefile
+++ b/immich/Makefile
@@ -42,4 +42,8 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'immich' 'machine-learning' 'redis' 'database' --default 'immich'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'immich' 'machine-learning' 'redis' 'database' --default 'immich'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/invidious/Makefile
+++ b/invidious/Makefile
@@ -33,4 +33,8 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'postgres' 'invidious' --default 'invidious'") && make --no-print-directory docker-compose-shell SERVICE=$${container} 
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'postgres' 'invidious' 'inv_sig_helper'--default 'invidious'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/lemmy/Makefile
+++ b/lemmy/Makefile
@@ -30,5 +30,8 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'proxy' 'config' 'lemmy' 'lemmy-ui' 'pictrs' 'postgres' 'postfix' --default 'proxy'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
-
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'proxy' 'config' 'lemmy' 'lemmy-ui' 'pictrs' 'postgres' 'postfix' --default 'proxy'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/minio/Makefile
+++ b/minio/Makefile
@@ -43,7 +43,11 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'minio' 'console' 'mc' --default 'minio'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'minio' 'console' 'mc' --default 'minio'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;
 
 .PHONY: open # Open the web-browser to the service URL
 open:

--- a/mopidy/Makefile
+++ b/mopidy/Makefile
@@ -17,7 +17,11 @@ config-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'mopidy' 'snapserver' 'drawio' --default 'mopidy'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'mopidy' 'snapserver' --default 'mopidy'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;
 
 .PHONY: library
 library:

--- a/nextcloud/Makefile
+++ b/nextcloud/Makefile
@@ -94,4 +94,8 @@ disable_maintenance:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'postgres' 'postgres_backup' 'redis' 'app' 'data_backup' 'cron' --default 'app'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'postgres' 'postgres_backup' 'redis' 'app' 'data_backup' 'cron' --default 'app'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/nginx/Makefile
+++ b/nginx/Makefile
@@ -46,12 +46,8 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@make --no-print-directory docker-compose-shell SERVICE=nginx
-
-.PHONY: shell-php
-shell-php:
-	@make --no-print-directory docker-compose-shell SERVICE=php-fpm
-
-.PHONY: shell-redis
-shell-redis:
-	@make --no-print-directory docker-compose-shell SERVICE=redis
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'nginx' 'php-fpm' 'redis' --default 'nginx'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/open-webui/Makefile
+++ b/open-webui/Makefile
@@ -34,4 +34,8 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'openwebui' 'ollama-$$(${BIN}/dotenv -f ${ENV_FILE} get DOCKER_COMPOSE_PROFILES)' --default 'openwebui'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'openwebui' 'ollama-$$(${BIN}/dotenv -f ${ENV_FILE} get DOCKER_COMPOSE_PROFILES)' --default 'openwebui'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/peertube/Makefile
+++ b/peertube/Makefile
@@ -39,7 +39,7 @@ config-hook:
 	@echo
 	@${BIN}/reconfigure_choose ${ENV_FILE} PEERTUBE_LIVESTREAMING "You can enable livestreaming via RTMP or RTMPS. Choose livestreaming status:" "Disabled" "RTMP" "RTMPS"
 	@echo
-	
+
 .PHONY: override-hook
 override-hook:
 #### This sets the override template variables for docker-compose.instance.yaml:
@@ -56,4 +56,8 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'peertube' 'postgres' 'redis' 'postfix' --default 'peertube'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'peertube' 'postgres' 'redis' 'postfix' --default 'peertube'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/photoprism/Makefile
+++ b/photoprism/Makefile
@@ -44,4 +44,8 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'photoprism' 'mariadb' --default 'photoprism'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'photoprism' 'mariadb' --default 'photoprism'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/piwigo/Makefile
+++ b/piwigo/Makefile
@@ -27,4 +27,8 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'db' 'piwigo' --default 'piwigo'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'db' 'piwigo' --default 'piwigo'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/plausible/Makefile
+++ b/plausible/Makefile
@@ -11,4 +11,8 @@ config-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'mail' 'db' 'events_db' 'app' --default 'app'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'mail' 'db' 'events_db' 'app' --default 'app'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/prometheus/Makefile
+++ b/prometheus/Makefile
@@ -36,14 +36,18 @@ override-hook:
 ####   name=@VARIABLE_NAME   # sets the template 'name' field to the literal string '${VARIABLE_NAME}'
 ####                         # (used for regular docker-compose expansion of env vars by name.)
 	@${BIN}/docker_compose_override ${ENV_FILE} project=:prometheus instance=@PROMETHEUS_INSTANCE traefik_host=@PROMETHEUS_METRICS_TRAEFIK_HOST http_auth=PROMETHEUS_HTTP_AUTH http_auth_var=@PROMETHEUS_HTTP_AUTH ip_sourcerange=@PROMETHEUS_METRICS_IP_SOURCERANGE oauth2=PROMETHEUS_OAUTH2 authorized_group=PROMETHEUS_OAUTH2_AUTHORIZED_GROUP enable_mtls_auth=PROMETHEUS_MTLS_AUTH mtls_authorized_certs=PROMETHEUS_MTLS_AUTHORIZED_CERTS
-	
+
 .PHONY: compose-profiles
 compose-profiles:
 	@${BIN}/reconfigure_compose_profiles ${ENV_FILE} PROMETHEUS_NODE_EXPORTER_ENABLED=node-exporter PROMETHEUS_CADVISOR_ENABLED=cadvisor PROMETHEUS_ALERTMANAGER_ENABLED=alertmanager
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'node-exporter' 'prometheus' 'grafana' 'cadvisor' 'alertmanager' 'alert-test' --default 'grafana'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'node-exporter' 'prometheus' 'grafana' 'cadvisor' 'alertmanager' 'alert-test' --default 'grafana'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;
 
 .PHONY: local-alertmanager # Forward alerts to local environment
 local-alertmanager:
@@ -52,5 +56,5 @@ local-alertmanager:
 .PHONY: test-alert # Perform a test alert
 test-alert:
 	@docker compose --env-file ${ENV_FILE} run --rm -it alert-test
-	@echo 
+	@echo
 	@echo "Sent test alert"

--- a/qbittorrent-wireguard/Makefile
+++ b/qbittorrent-wireguard/Makefile
@@ -22,7 +22,11 @@ config-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'wireguard' 'qbittorrent' --default 'qbittorrent'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'wireguard' 'qbittorrent' --default 'qbittorrent'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;
 
 .PHONY: check-vpn
 check-vpn:

--- a/redmine/Makefile
+++ b/redmine/Makefile
@@ -32,7 +32,11 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'redmine' 'db' --default 'redmine'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'redmine' 'db' --default 'redmine'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;
 
 .PHONY: install-plugins # Install Redmine plugins
 install-plugins:

--- a/searxng/Makefile
+++ b/searxng/Makefile
@@ -30,4 +30,8 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'searxng' 'redis' --default 'searxng'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'searxng' 'redis' --default 'searxng'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/speedtest-tracker/Makefile
+++ b/speedtest-tracker/Makefile
@@ -16,11 +16,11 @@ config-hook:
 		${BIN}/reconfigure ${ENV_FILE} SPEEDTEST_TRACKER_PUBLIC_DASHBOARD=true || \
 		${BIN}/reconfigure ${ENV_FILE} SPEEDTEST_TRACKER_PUBLIC_DASHBOARD=false
 	@echo
-	@${BIN}/reconfigure_ask ${ENV_FILE} SPEEDTEST_TRACKER_DISPLAY_TIMEZONE "Enter the timezone you want timestamps to be displayed in" 
+	@${BIN}/reconfigure_ask ${ENV_FILE} SPEEDTEST_TRACKER_DISPLAY_TIMEZONE "Enter the timezone you want timestamps to be displayed in"
 	@echo
-	@${BIN}/reconfigure_ask ${ENV_FILE} SPEEDTEST_TRACKER_SCHEDULE "Enter the cron expression used to run speedtests on a scheduled basis" 
+	@${BIN}/reconfigure_ask ${ENV_FILE} SPEEDTEST_TRACKER_SCHEDULE "Enter the cron expression used to run speedtests on a scheduled basis"
 	@echo
-	@${BIN}/reconfigure_ask ${ENV_FILE} SPEEDTEST_TRACKER_PRUNE_RESULTS_OLDER_THAN "Enter the number of days to keep results for, or enter 0 (zero) to keep all results" 
+	@${BIN}/reconfigure_ask ${ENV_FILE} SPEEDTEST_TRACKER_PRUNE_RESULTS_OLDER_THAN "Enter the number of days to keep results for, or enter 0 (zero) to keep all results"
 	@echo
 	@${BIN}/reconfigure ${ENV_FILE} SPEEDTEST_TRACKER_APP_KEY=$$(openssl rand -base64 32)
 	@${BIN}/reconfigure ${ENV_FILE} SPEEDTEST_TRACKER_APP_KEY=$$(key=$$(${BIN}/dotenv -f ${ENV_FILE} get SPEEDTEST_TRACKER_APP_KEY); [[ "$${key}" == base64:* ]] && echo "$${key}" || echo "base64:$${key}")
@@ -44,7 +44,7 @@ override-hook:
 .PHONY: shell
 shell:
 	@make --no-print-directory docker-compose-shell SERVICE=speedtest-tracker
-	
+
 .PHONY: show-password # Show the admin login's initial password
 show-password:
 	@echo

--- a/ttrss/Makefile
+++ b/ttrss/Makefile
@@ -29,4 +29,8 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'db' 'app' 'backups' 'updater' 'web-nginx' --default 'app'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'db' 'app' 'backups' 'updater' 'web-nginx' --default 'app'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/whoami/Makefile
+++ b/whoami/Makefile
@@ -30,3 +30,11 @@ override-hook:
 .PHONY: shell # Enter container shell
 shell:
 	@make --no-print-directory docker-compose-shell SERVICE=whoami
+
+.PHONY: shell-menu
+shell-menu:
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'whoami' --default 'whoami'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;

--- a/wordpress/Makefile
+++ b/wordpress/Makefile
@@ -36,7 +36,11 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'wp' 'db' --default 'wp'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'wp' 'db' --default 'wp'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;
 
 open-hook:
 	${BIN}/open /wp-admin

--- a/xbs/Makefile
+++ b/xbs/Makefile
@@ -13,7 +13,11 @@ config-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'db' 'api' --default 'api'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'db' 'api' --default 'api'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;
 
 .PHONY: override-hook
 override-hook:

--- a/yourls/Makefile
+++ b/yourls/Makefile
@@ -31,7 +31,11 @@ override-hook:
 
 .PHONY: shell
 shell:
-	@container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'yourls' 'mysql' --default 'yourls'") && make --no-print-directory docker-compose-shell SERVICE=$${container}
+	@if [ -z "$(service)" ]; then \
+		container=$$(eval "${BIN}/script-wizard choose 'docker exec -it into which container?' 'yourls' 'mysql' --default 'yourls'") && make --no-print-directory docker-compose-shell SERVICE=$${container}; \
+	else \
+		make --no-print-directory docker-compose-shell SERVICE=$$(service); \
+	fi;
 
 open-hook:
 	${BIN}/open /admin


### PR DESCRIPTION
For every service that has more than 1 container you might want to visit, I left the `make shell` menu but also added back the `make shell service=xxx` functionality.

Resolves #454 