### PR TITLE
Add dev environment option for Swagger

### DIFF
--- a/open-webui/.env-dist
+++ b/open-webui/.env-dist
@@ -63,5 +63,11 @@ OPENWEBUI_MODELS_HOST_PATH=
 ## other services you host).
 OPENWEBUI_EXPOSE_OLLAMA=false
 
+## Set to `prod` for production environment, or to `dev` for
+## development environment. Swagger-like API docs
+## (https://openwebui.example.com/docs) are only available in the
+## `dev` environemnt.
+OPENWEBUI_ENV=prod
+
 # META:
 # PREFIX=OPENWEBUI

--- a/open-webui/docker-compose.yaml
+++ b/open-webui/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
     restart: unless-stopped
     environment:
       - OLLAMA_BASE_URL=http://ollama-${DOCKER_COMPOSE_PROFILES}:11434
+      - ENV=${OPENWEBUI_ENV}
     volumes:
       - openwebui:/app/backend/data
       - ollama:/root/.ollama


### PR DESCRIPTION
Swagger is only available in openwebui's dev environment. Added env var to change environment.

Resolved #480 