### PR TITLE
Fix ComfyUI update mechanism

### DIFF
--- a/comfyui/Dockerfile
+++ b/comfyui/Dockerfile
@@ -53,5 +53,6 @@ ARG HSA_OVERRIDE_GFX_VERSION
 ENV HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION}
 ARG LOG_LEVEL
 ENV LOG_LEVEL=${LOG_LEVEL}
+VOLUME /ComfyUI
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python3", "main.py", "--multi-user", "--listen 0.0.0.0", "--verbose", "${LOG_LEVEL}"]


### PR DESCRIPTION
ComfyUI Manager has a feature to update ComfyUI from within the UI itself (and to switch between versions), but it throws an error.

The problem is that Dockerfile clones the specific tag for the version the user wants to install - it doesn't clone the master branch, which ComfyUI Manager's "Update ComfyUI" function requires.

Fixes #517 