### PR TITLE
Update DSP privs for Uptime Kuma

### DIFF
--- a/uptime-kuma/docker-compose.yaml
+++ b/uptime-kuma/docker-compose.yaml
@@ -25,6 +25,8 @@ services:
       # ---- Reads that might be needed ----
       - INFO=1                 # GET /info (daemon info).
       - CONTAINERS=1           # GET /containers/json and /containers/{id}/json.
+      - SERVICES=1
+      - TASKS=0
     read_only: true
     tmpfs:
       - /tmp:rw,nosuid,nodev,noexec,size=16m


### PR DESCRIPTION
Per [this comment](https://github.com/louislam/uptime-kuma/issues/2061#issuecomment-2295240126), I updated the docker-socket-proxy privs for Uptime Kuma.

FYI, [here](https://github.com/louislam/uptime-kuma/issues/2061#issuecomment-2295240126) are all of DSP's privs.