### PR TITLE
Add plain-text/json/xml response formatter to include DOCKER_CONTEXT

### DIFF
--- a/traefik/docker-compose.yaml
+++ b/traefik/docker-compose.yaml
@@ -271,6 +271,9 @@ services:
     restart: unless-stopped
     environment:
       TEMPLATE_NAME: ${TRAEFIK_ERROR_PAGES_TEMPLATE}
+      RESPONSE_PLAINTEXT_FORMAT: "${DOCKER_CONTEXT} | {{ code }} | {{ message }}"
+      RESPONSE_JSON_FORMAT: "{\"error\":{\"status\":{{ code }},\"detail\":{{ printf \"%q\" description }}, \"context\": \"${DOCKER_CONTEXT}\"}}"
+      RESPONSE_XML_FORMAT: "<error><code>{{ code }}</code><description>{{ description }}</description><context>${DOCKER_CONTEXT}</context></error>"
     labels:
       traefik.enable: true
       # use as "fallback" for any NON-registered services (with priority below normal)


### PR DESCRIPTION
Adds DOCKER_CONTEXT to the error-pages response formatters:

```
$ curl -H "Accept: text/plain" https://asdf.mrfusion.rymcg.tech && echo
mrfusion-nvidia | 404 | Not Found

$ curl -H "Accept: application/json" https://asdf.mrfusion.rymcg.tech && echo
{"error":{"status":404,"detail":"The server can not find the requested page", "context": "mrfusion-nvidia"}}

$ curl -H "Accept: application/xml" https://asdf.mrfusion.rymcg.tech && echo
<error><code>404</code><description>The server can not find the requested page</description><context>mrfusion-nvidia</context></error>

```