### PR TITLE
Add llama.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Install these applications at your preference:
 * [Jupyterlab](jupyterlab#readme) - a web based code editing environment / reproducible research tool
 * [Kokoro Web](kokoro#readme) - a browser-based AI voice generator that lets you create natural-sounding voices
 * [Lemmy](lemmy#readme) - a link aggregator and forum for the fediverse
+* [llama.cpp](llama-cpp#readme) - an LLM inference engine with an OpenAI-compatible API for serving GGUF models
 * [Matterbridge](matterbridge#readme) - a chat room bridge (IRC, Matrix, XMPP, etc)
 * [Maubot](maubot#readme) - a matrix Bot
 * [Minio](minio#readme) - an S3 storage server

--- a/llama-cpp/.env-dist
+++ b/llama-cpp/.env-dist
@@ -1,0 +1,130 @@
+# The base docker image for llama.cpp (tag is constructed from LLAMA_IMAGE_VARIANT + profile suffix):
+# Available variants: server, full, light
+# GPU profiles append: -cuda, -rocm (e.g., server-cuda, full-rocm)
+# See https://github.com/ggml-org/llama.cpp/blob/master/docs/docker.md
+LLAMA_IMAGE=ghcr.io/ggml-org/llama.cpp
+
+# Which image variant to use:
+# server - only llama-server (smallest, recommended for API-only use)
+# full   - llama-server + model conversion tools + quantization tools
+# light  - llama-server + llama-cli (minimal)
+LLAMA_IMAGE_VARIANT=server
+
+# The domain name for the llama.cpp service:
+LLAMA_TRAEFIK_HOST=llama.example.com
+
+# The name of this instance. If there is only one instance, use 'default'.
+LLAMA_INSTANCE=
+# You can protect this instance from uninstallation by setting this true:
+## If true, make this instance immune to: `make uninstall`, `make destroy`
+## Still allowed regardless: `make install`, `make stop`, `make start`, `make restart`
+LLAMA_INSTANCE_PROTECTION=false
+
+## Enter the profile for the processing engine: cuda (for nvidia
+## GPUs), rocm (for AMD GPUs), or cpu (to use only the CPU).
+DOCKER_COMPOSE_PROFILES=cpu
+
+# For AMD GPUs that ROCm doesn't officially support, you can try
+# setting LLAMA_HSA_OVERRIDE_GFX_VERSION to a value that matches
+# your GPU's architecture (e.g., if you run `rocminfo` on the host
+# with the AMD GPU and the "Name" of your GPU is
+# "amdgcn-amd-amdhsa--gfx1030", you'd enter the value `10.3.0`). If
+# your GPU is supported by ROCm or if you're using a non-AMD GPU,
+# leave LLAMA_HSA_OVERRIDE_GFX_VERSION unset.
+LLAMA_HSA_OVERRIDE_GFX_VERSION=
+
+## Leave LLAMA_MODELS_HOST_PATH blank to save models in the named
+## Docker volume for the llama.cpp container, or enter a path on the host
+## to save them there.
+LLAMA_MODELS_HOST_PATH=
+
+# The internal port for llama-server (default 8080):
+LLAMA_SERVER_PORT=8080
+
+# Path to the initial model to load at startup (inside the container).
+# e.g., /models/model.gguf
+# Leave blank to start in router mode and load models on-demand.
+LLAMA_INITIAL_MODEL=
+
+# Maximum number of models loaded simultaneously (router mode).
+# Least-recently-used models are evicted when this limit is reached.
+# Set to 0 for unlimited (no eviction).
+LLAMA_MODELS_MAX=4
+
+# Number of layers to offload to GPU. Leave blank for auto-detection.
+# Set to 99 or a high number to offload all layers.
+LLAMA_N_GPU_LAYERS=
+
+# Context length. Leave blank to use the model's native default.
+LLAMA_CONTEXT_LENGTH=
+
+# Automatically unload models after this many seconds of inactivity.
+# When idle, llama.cpp unloads the model from GPU/RAM to conserve resources.
+# Any new request automatically triggers a reload.
+# Leave blank to disable (models stay loaded until evicted by LRU).
+LLAMA_SLEEP_IDLE_SECONDS=300
+
+# Enable Jinja templating for function/tool calling support.
+# Required for OpenAI-compatible tool calling (e.g., web search in Open WebUI).
+LLAMA_JINJA=true
+
+# Enable built-in tools for llama.cpp's own web UI agent.
+# Set to "all" to enable all built-in tools, or a comma-separated list:
+# read_file,file_glob_search,grep_search,exec_shell_command,write_file,edit_file,apply_diff
+# Leave blank to disable built-in tools.
+#
+# Note: Built-in tools run inside the llama.cpp container and can only
+# access files within it (e.g., /models/). They are useful for the
+# built-in web UI to act as a standalone assistant that can read/write
+# files inside the container.
+#
+# External coding agents (e.g., Open WebUI, Cursor, etc.) do NOT use
+# built-in tools. They use the OpenAI-compatible tool calling API:
+# llama.cpp generates tool call requests, and the external agent
+# executes them on the host. Built-in tools are irrelevant for this
+# pattern.
+LLAMA_TOOLS=
+
+## Configure an API token required to access the API:
+## Leave blank to disable the token requirement.
+LLAMA_API_TOKEN=
+
+# HuggingFace API token for gated/private models.
+# Leave blank for public models.
+LLAMA_HF_TOKEN=
+
+# Filter access by IP address source range (CIDR):
+##Disallow all access: 0.0.0.0/32
+##Allow all access: 0.0.0.0/0
+LLAMA_IP_SOURCERANGE=0.0.0.0/0
+
+# HTTP Basic Authentication:
+# Use `make config` to fill this in properly, or set this to blank to disable.
+LLAMA_HTTP_AUTH=
+
+# OAUTH2
+# Set to `true` to use OpenID/OAuth2 authentication via the
+# traefik-forward-auth service in d.rymcg.tech.
+# Using OpenID/OAuth2 will require login to access your app,
+# but it will not affect what a successfully logged-in person can do in your
+# app. If your app has built-in authentication and can check the user
+# header that traefik-forward-auth sends, then your app can limit what the
+# logged-in person can do in the app. But if your app can't check the user
+# header, or if your app doesn't have built-in authentication at all, then
+# any person with your Forgejo server can log into your app and
+# have full access.
+LLAMA_OAUTH2=false
+# In addition to Oauth2 authentication, you can configure basic authorization
+# by entering which authorization group can log into your app. You create
+# groups of email addresses in the `traefik` folder by running `make groups`.
+LLAMA_OAUTH2_AUTHORIZED_GROUP=
+
+# Mutual TLS (mTLS):
+# Set true or false. If true, all clients must present a certificate signed by Step-CA:
+LLAMA_MTLS_AUTH=false
+# Enter a comma separated list of client domains allowed to connect via mTLS.
+# Wildcards are allowed and encouraged on a per-app basis:
+LLAMA_MTLS_AUTHORIZED_CERTS=*.clients.llama.example.com
+
+# META:
+# PREFIX=LLAMA

--- a/llama-cpp/.gitignore
+++ b/llama-cpp/.gitignore
@@ -1,0 +1,4 @@
+.env_*
+docker-compose.override_*.yaml
+passwords.json
+TODO.md

--- a/llama-cpp/Makefile
+++ b/llama-cpp/Makefile
@@ -1,0 +1,90 @@
+ROOT_DIR = ..
+include ${ROOT_DIR}/_scripts/Makefile.projects
+include ${ROOT_DIR}/_scripts/Makefile.instance
+
+.PHONY: config-hook
+config-hook:
+#### This interactive configuration wizard creates the .env_{DOCKER_CONTEXT}_{INSTANCE} config file using .env-dist as the template:
+#### reconfigure_ask asks the user a question to set the variable into the .env file, and with a provided default value.
+#### reconfigure sets the value of a variable in the .env file without asking.
+#### reconfigure_htpasswd will configure the HTTP Basic Authentication setting the var name and with a provided default value.
+	@${BIN}/reconfigure_ask ${ENV_FILE} LLAMA_TRAEFIK_HOST "Enter the llama.cpp domain name" llama${INSTANCE_URL_SUFFIX}.${ROOT_DOMAIN}
+	@${BIN}/reconfigure ${ENV_FILE} LLAMA_INSTANCE=$${instance:-default}
+	@${BIN}/reconfigure_auth ${ENV_FILE} LLAMA
+	@echo ""
+	@echo "Enter the processing engine to use: cuda (for nvidia GPUs), rocm (for AMD GPUs), or cpu (to use only the CPU)."
+	@${BIN}/reconfigure_compose_profiles_choose ${ENV_FILE} rocm="AMD GPU" cuda="Nvidia GPU" cpu="CPU only"
+	@echo ""
+	@if [[ "$$(${BIN}/dotenv -f ${ENV_FILE} get DOCKER_COMPOSE_PROFILES)" == "rocm" ]]; then \
+	    echo "If your GPU isn't officially supported by ROCm, you can set LLAMA_HSA_OVERRIDE_GFX_VERSION to a value that matches your GPU's architecture (e.g., \"10.3.0\"). Leave blank if your GPU is supported by ROCm."; \
+		ALLOW_BLANK=1 ${BIN}/reconfigure_ask ${ENV_FILE} LLAMA_HSA_OVERRIDE_GFX_VERSION "Enter your AMD GPU's architecture version" ; \
+		echo ""; \
+	else \
+		${BIN}/reconfigure ${ENV_FILE} "LLAMA_HSA_OVERRIDE_GFX_VERSION="; \
+	fi
+	@${BIN}/reconfigure_choose ${ENV_FILE} LLAMA_IMAGE_VARIANT "Select the image variant:" server full light
+	@echo ""
+	@ALLOW_BLANK=1 ${BIN}/reconfigure_ask ${ENV_FILE} LLAMA_MODELS_HOST_PATH "If you want to save models in a specific directory on the host, enter the path here, or leave blank to save models to the llama.cpp container's named Docker volume."
+	@echo
+	@${BIN}/reconfigure_ask ${ENV_FILE} LLAMA_SERVER_PORT "Enter the internal server port for llama-server" 8080
+	@echo
+	@ALLOW_BLANK=1 ${BIN}/reconfigure_ask ${ENV_FILE} LLAMA_INITIAL_MODEL "Enter the path to the initial model to load at startup (inside container, e.g., /models/model.gguf), or leave blank to switch between models on the fly via the web UI or API."
+	@echo
+	@ALLOW_BLANK=1 ${BIN}/reconfigure_ask ${ENV_FILE} LLAMA_N_GPU_LAYERS "Enter the number of layers to offload to GPU (leave blank for auto-detection, or set to 99 for all layers)."
+	@echo
+	@ALLOW_BLANK=1 ${BIN}/reconfigure_ask ${ENV_FILE} LLAMA_CONTEXT_LENGTH "Enter the context length (leave blank for model default)."
+	@echo
+	@ALLOW_BLANK=1 ${BIN}/reconfigure_ask ${ENV_FILE} LLAMA_MODELS_MAX "Enter the maximum number of models loaded simultaneously (LRU eviction, 0 for unlimited, default 4)." 4
+	@echo
+	@${BIN}/confirm $$(test -n "$$(${BIN}/dotenv -f ${ENV_FILE} get LLAMA_API_TOKEN)" && echo yes || echo no) "Do you want to require an API token to access this service" "?" && ( \
+	    ${BIN}/reconfigure_password ${ENV_FILE} LLAMA_API_TOKEN 45 \
+	) || ( \
+	    ${BIN}/reconfigure ${ENV_FILE} "LLAMA_API_TOKEN=" \
+	)
+	@echo
+
+.PHONY: override-hook
+override-hook:
+#### This sets the override template variables for docker-compose.instance.yaml:
+#### The template dynamically renders to docker-compose.override_{DOCKER_CONTEXT}_{INSTANCE}.yaml
+#### These settings are used to automatically generate the service container labels, and traefik config, inside the template.
+#### The variable arguments have three forms: `=` `=:` `=@`
+####   name=VARIABLE_NAME    # sets the template 'name' field to the value of VARIABLE_NAME found in the .env file
+####                         # (this hardcodes the value into docker-compose.override.yaml)
+####   name=:VARIABLE_NAME   # sets the template 'name' field to the literal string 'VARIABLE_NAME'
+####                         # (this hardcodes the string into docker-compose.override.yaml)
+####   name=@VARIABLE_NAME   # sets the template 'name' field to the literal string '${VARIABLE_NAME}'
+####                         # (used for regular docker-compose expansion of env vars by name.)
+	@${BIN}/docker_compose_override ${ENV_FILE} project=:llama instance=@LLAMA_INSTANCE traefik_host=@LLAMA_TRAEFIK_HOST http_auth=LLAMA_HTTP_AUTH http_auth_var=@LLAMA_HTTP_AUTH ip_sourcerange=@LLAMA_IP_SOURCERANGE oauth2=LLAMA_OAUTH2 authorized_group=LLAMA_OAUTH2_AUTHORIZED_GROUP enable_mtls_auth=LLAMA_MTLS_AUTH mtls_authorized_certs=LLAMA_MTLS_AUTHORIZED_CERTS models_host_path=LLAMA_MODELS_HOST_PATH compose_profile=DOCKER_COMPOSE_PROFILES api_token=LLAMA_API_TOKEN server_port=LLAMA_SERVER_PORT initial_model=LLAMA_INITIAL_MODEL n_gpu_layers=LLAMA_N_GPU_LAYERS context_length=LLAMA_CONTEXT_LENGTH image_variant=LLAMA_IMAGE_VARIANT models_max=LLAMA_MODELS_MAX jinja=LLAMA_JINJA tools=LLAMA_TOOLS sleep_idle_seconds=LLAMA_SLEEP_IDLE_SECONDS
+
+.PHONY: shell
+shell:
+	@make --no-print-directory docker-compose-shell SERVICE=llama-$$(${BIN}/dotenv -f ${ENV_FILE} get DOCKER_COMPOSE_PROFILES)
+
+.PHONY: add-models # Download models from HuggingFace or direct URLs and add them to llama.cpp
+add-models:
+	@${ROOT_DIR}/llama-cpp/llama-add-models llama-$$(${BIN}/dotenv -f ${ENV_FILE} get DOCKER_COMPOSE_PROFILES) $$(${BIN}/dotenv -f ${ENV_FILE} get LLAMA_HF_TOKEN) ${ENV_FILE}
+
+.PHONY: list-models # List all models in /models/ 
+list-models:
+	@${ROOT_DIR}/llama-cpp/llama-list-models llama-$$(${BIN}/dotenv -f ${ENV_FILE} get DOCKER_COMPOSE_PROFILES) ${ENV_FILE}
+
+.PHONY: list-models-json # List all models llama.cpp has detected (JSON output)
+list-models-json:
+	@${ROOT_DIR}/llama-cpp/llama-list-models --json llama-$$(${BIN}/dotenv -f ${ENV_FILE} get DOCKER_COMPOSE_PROFILES) ${ENV_FILE}
+
+.PHONY: delete-models # Delete selected models from /models/
+delete-models:
+	@${ROOT_DIR}/llama-cpp/llama-delete-models llama-$$(${BIN}/dotenv -f ${ENV_FILE} get DOCKER_COMPOSE_PROFILES) ${ENV_FILE}
+
+.PHONY: manage-model-configs # Edit per-model JSON configuration files
+manage-model-configs:
+	@${ROOT_DIR}/llama-cpp/llama-manage-model-configs llama-$$(${BIN}/dotenv -f ${ENV_FILE} get DOCKER_COMPOSE_PROFILES) ${ENV_FILE}
+
+.PHONY: install-hook
+install-hook:
+	@echo
+
+.PHONY: install-hook-pre
+install-hook-pre:
+	@echo

--- a/llama-cpp/README.md
+++ b/llama-cpp/README.md
@@ -1,0 +1,237 @@
+# llama.cpp
+
+[llama.cpp](https://github.com/ggml-org/llama.cpp) is a high-performance
+LLM inference engine written in C/C++. This service runs the
+`llama-server` which provides an OpenAI-compatible API for serving
+GGUF models.
+
+## Config
+
+```
+make config
+```
+
+This will ask you to enter the domain name to use, select the GPU
+profile (cpu/cuda/rocm), choose the image variant (server/full/light),
+and configure model storage. It automatically saves your responses
+into the configuration file `.env_{DOCKER_CONTEXT}_{INSTANCE}`.
+
+### Image Variants
+
+- **server** - Only `llama-server` (smallest, recommended for API-only use)
+- **full** - `llama-server` + model conversion tools + quantization tools
+- **light** - `llama-server` + `llama-cli` (minimal)
+
+### Authentication and Authorization
+
+You may add an API token to secure your service by setting
+`LLAMA_API_TOKEN` in the `.env_{CONTEXT}_{INSTANCE}` file.
+
+See [AUTH.md](../AUTH.md) for information on adding external
+authentication on top of your app.
+
+## Install
+
+```
+make install
+```
+
+## Using llama.cpp
+
+llama.cpp server provides an OpenAI-compatible REST API and includes a
+built-in web UI for model selection and chat. Access the web UI at
+`https://{LLAMA_TRAEFIK_HOST}`.
+
+### API Documentation
+
+- [llama.cpp server API](https://github.com/ggml-org/llama.cpp/blob/master/docs/server/README.md)
+- [OpenAI-compatible API](https://github.com/ggml-org/llama.cpp/blob/master/docs/server/usage.md)
+
+### Tool Calling and Web Search
+
+Function/tool calling is enabled by default via the `--jinja` flag
+(`LLAMA_JINJA=true`). This allows consuming services like Open WebUI
+to use tool calling for features like web search, code execution, and
+more.
+
+Note that llama.cpp only **generates tool call requests** — it does not
+execute tools itself. The consuming service (e.g., Open WebUI, Cursor,
+or any external coding agent) must handle tool execution and return
+results to the model.
+
+#### Built-in Tools
+
+llama.cpp also supports **built-in tools** that run inside the container
+itself (via the `--tools` flag, controlled by `LLAMA_TOOLS`). These allow
+llama.cpp's own web UI to act as a standalone assistant that can read/write
+files and execute shell commands **inside the container**.
+
+Available built-in tools: `read_file`, `write_file`, `edit_file`,
+`apply_diff`, `exec_shell_command`, `file_glob_search`, `grep_search`.
+
+**Built-in tools are disabled by default** (`LLAMA_TOOLS=`) because they
+only have access to files inside the container (e.g., `/models/`). They
+are not useful for external coding agents, which use the OpenAI-compatible
+tool calling API instead — the agent executes tools on the host, and
+llama.cpp only generates the tool call requests.
+
+To enable built-in tools, set `LLAMA_TOOLS=all` in your `.env` file and
+run `make reinstall`.
+
+### Idle Model Unloading
+
+llama.cpp can automatically unload models from GPU/RAM after a period of
+inactivity to conserve resources. Any new request will automatically
+trigger a reload.
+
+```
+LLAMA_SLEEP_IDLE_SECONDS=300
+```
+
+Set the number of seconds of idleness before the server enters sleep mode.
+Leave blank to disable (models stay loaded until evicted by LRU).
+
+### Model Management
+
+Models are stored in the `/models` directory inside the container,
+which is backed by either a Docker volume or a host path (configured
+via `LLAMA_MODELS_HOST_PATH`).
+
+The server runs in **router mode** with `--models-dir /models`, which
+auto-discovers all `.gguf` files. Models are evicted using LRU when
+`LLAMA_MODELS_MAX` is reached.
+
+**Important:** The model file changes (adding or deleting `.gguf` files)
+are **not automatically detected** by llama.cpp at runtime. After adding
+or removing models, you must restart the service for llama.cpp to
+recognize the changes:
+
+```
+make restart
+```
+
+A [model reload endpoint](https://github.com/ggml-org/llama.cpp/issues/21779)
+is being developed upstream that will allow llama.cpp to rescan its models
+directory without a restart. Once available, this will be integrated into
+the model management targets.
+
+#### Adding Models
+
+```
+make add-models
+```
+
+Prompts you for model sources. Supports:
+- **Direct URLs**: `https://huggingface.co/user/repo/resolve/main/model.gguf`
+- **HF identifier with file**: `user/repo:filename.gguf`
+- **HF identifier alone**: `user/repo` (lists available `.gguf` files to choose from)
+
+For gated/private models, set `LLAMA_HF_TOKEN` in your `.env` file.
+
+After downloading, run `make restart` to make the new model available
+in llama.cpp.
+
+#### Listing Models
+
+```
+make list-models
+```
+
+Lists all `.gguf` files in `/models/`, one per line, with their model
+ID (filename without extension):
+
+```
+Bonsai-1.7B-Q1_0.gguf (Bonsai-1.7B-Q1_0)
+Qwen3.6-35B-A3B-UD-Q8_K_XL.gguf (Qwen3.6-35B-A3B-UD-Q8_K_XL)
+```
+
+For JSON output (from the llama.cpp API, showing only loaded models):
+
+```
+make list-models-json
+```
+
+#### Deleting Models
+
+```
+make delete-models
+```
+
+Interactive multi-select menu to remove models from `/models/`. If any
+of the selected models have corresponding `.json` configuration files,
+you'll be prompted to select which config files to delete as well
+(all pre-selected by default).
+
+After deleting, run `make restart` if the deleted model was currently
+loaded in memory.
+
+#### Manual Model Placement
+
+You can also place `.gguf` files directly:
+- **Host path**: Copy files to the path configured in `LLAMA_MODELS_HOST_PATH`
+- **Docker volume**: Use `make shell` and download via `curl` inside the container
+
+#### Per-Model JSON Configuration
+
+For each model `.gguf` file, you can create a companion `.json` file in
+the `/models/` directory (on the host or inside the container) with the
+same basename to set per-model runtime overrides. For example, alongside
+`my-model.gguf`, create `my-model.json`:
+
+```json
+{
+  "n_ctx": 32768,
+  "n_batch": 4096,
+  "n_ubatch": 512,
+  "tensor_split": [0.5, 0.5],
+  "rope_scaling_type": "linear",
+  "rope_freq_base": 1000000
+}
+```
+
+This lets you tune context size, batch size, tensor split across GPUs,
+Rope scaling, and any other `llama-server` parameter on a per-model
+basis without maintaining separate containers or configurations.
+
+See the [llama.cpp server usage docs](https://github.com/ggml-org/llama.cpp/blob/master/docs/server/usage.md)
+for the full list of supported options.
+
+##### Managing Model Configs Interactively
+
+```
+make manage-model-configs
+```
+
+This target provides an interactive wizard that:
+
+1. Lists all models and prompts you to select one
+2. Downloads the existing `.json` config if it exists, or creates a new one from a template (pulling defaults from your `.env` file)
+3. Opens the file in your `$EDITOR` (falls back to `nano` if unset)
+4. Validates the JSON before uploading
+5. If the model is currently loaded, unloads and reloads it to apply the new configuration
+
+##### Manual Configuration
+
+You can also place `.json` files directly in the `/models/` directory.
+After adding or updating a `.json` file manually, restart the service:
+
+```
+make restart
+```
+
+### Shell Access
+
+```
+make shell
+```
+
+Enter the container shell to run `llama-cli`, `llama-quantize`, or
+other tools (available depending on the image variant selected).
+
+## Destroy
+
+```
+make destroy
+```
+
+This completely removes the container and deletes all its volumes.

--- a/llama-cpp/docker-compose.instance.yaml
+++ b/llama-cpp/docker-compose.instance.yaml
@@ -1,0 +1,124 @@
+#! This is a ytt template file for docker-compose.override.yaml
+#! References:
+#!   https://carvel.dev/ytt
+#!   https://docs.docker.com/compose/extends/#adding-and-overriding-configuration
+#!   https://github.com/enigmacurry/d.rymcg.tech#overriding-docker-composeyaml-per-instance
+
+#! ### Standard project vars:
+#@ load("@ytt:data", "data")
+#@ project = data.values.project
+#@ instance = data.values.instance
+#@ context = data.values.context
+#@ traefik_host = data.values.traefik_host
+#@ ip_sourcerange = data.values.ip_sourcerange
+#@ enable_http_auth = len(data.values.http_auth.strip()) > 0
+#@ http_auth = data.values.http_auth_var
+#@ enable_oauth2 = data.values.oauth2 == "true"
+#@ authorized_group = data.values.authorized_group
+#@ enable_mtls_auth = data.values.enable_mtls_auth == "true"
+#@ mtls_authorized_certs = data.values.mtls_authorized_certs
+#@ enabled_middlewares = []
+
+#! ### Project-specific vars:
+#@ models_host_path = data.values.models_host_path
+#@ compose_profile = data.values.compose_profile
+#@ api_token = data.values.api_token
+#@ server_port = data.values.server_port
+#@ initial_model = data.values.initial_model
+#@ n_gpu_layers = data.values.n_gpu_layers
+#@ context_length = data.values.context_length
+#@ image_variant = data.values.image_variant
+#@ models_max = data.values.models_max
+#@ jinja = data.values.jinja
+#@ tools = data.values.tools
+#@ sleep_idle_seconds = data.values.sleep_idle_seconds
+
+#@ def llama_service(profile):
+#@   service = "llama-" + profile
+#@   env = []
+#@   if api_token.strip():
+#@     env.append("LLAMA_API_KEY=${LLAMA_API_TOKEN}")
+#@   end
+#@   if context_length.strip():
+#@     env.append("LLAMA_CONTEXT_LENGTH=${LLAMA_CONTEXT_LENGTH}")
+#@   end
+#@   if n_gpu_layers.strip():
+#@     env.append("LLAMA_N_GPU_LAYERS=${LLAMA_N_GPU_LAYERS}")
+#@   end
+#@   cmd = []
+#@   if image_variant != "server":
+#@     cmd.append("--server")
+#@   end
+#@   cmd.extend(["--host", "0.0.0.0", "--port", server_port, "--models-dir", "/models"])
+#@   if models_max.strip() and models_max.strip() != "0":
+#@     cmd.extend(["--models-max", models_max])
+#@   end
+#@   if initial_model.strip():
+#@     cmd.extend(["-m", initial_model])
+#@   end
+#@   if jinja == "true":
+#@     cmd.append("--jinja")
+#@   end
+#@   if tools.strip():
+#@     cmd.extend(["--tools", tools])
+#@   end
+#@   if sleep_idle_seconds.strip():
+#@     cmd.extend(["--sleep-idle-seconds", sleep_idle_seconds])
+#@   end
+#@   router = "{}-{}-{}".format(project, instance, service)
+#@   labels = []
+#@   middlewares = []
+#@   labels.append("backup-volume.stop-during-backup=true")
+#@   labels.append("traefik.enable=true")
+#@   labels.append("traefik.http.routers.{}.rule=Host(`{}`)".format(router, traefik_host))
+#@   labels.append("traefik.http.routers.{}.entrypoints=websecure".format(router))
+#@   middlewares.append("{}-ipallowlist".format(router))
+#@   labels.append("traefik.http.middlewares.{}-ipallowlist.ipallowlist.sourcerange={}".format(router, ip_sourcerange))
+#@   if enable_http_auth:
+#@     middlewares.append("{}-basicauth".format(router))
+#@     labels.append("traefik.http.middlewares.{}-basicauth.basicauth.users={}".format(router, http_auth))
+#@     labels.append("traefik.http.middlewares.{}-basicauth.basicauth.headerField=X-Forwarded-User".format(router))
+#@   end
+#@   if enable_oauth2:
+#@     middlewares.append("traefik-forward-auth@docker")
+#@     middlewares.append("header-authorization-group-{}@file".format(authorized_group))
+#@   end
+#@   if enable_mtls_auth:
+#@     labels.append("traefik.http.routers.{}.tls.options=step_ca_mTLS@file".format(router))
+#@     if len(mtls_authorized_certs):
+#@       labels.append("traefik.http.middlewares.mtlsauth-{}.plugin.certauthz.domains={}".format(router, mtls_authorized_certs))
+#@       middlewares.append("mtlsauth-{}".format(router))
+#@     end
+#@     middlewares.append("mtls-header@file")
+#@   end
+#@   labels.append("traefik.http.routers.{}.middlewares={}".format(router, ",".join(middlewares)))
+#@   labels.append("traefik.http.services.{}.loadbalancer.server.port={}".format(router, server_port))
+#@   if models_host_path != "":
+#@     volumes = ["{}:/models".format(models_host_path)]
+#@   else:
+#@     volumes = ["llama:/models"]
+#@   end
+#@   return {
+#@     service: {
+#@       "volumes": volumes,
+#@       "labels": labels,
+#@       "environment": env,
+#@       "command": cmd
+#@     }
+#@   }
+#@ end
+
+#@yaml/text-templated-strings
+services:
+  #@ service_def = llama_service(compose_profile)
+  #@ for name, config in service_def.items():
+  (@= name @):
+    #@ for key, val in config.items():
+    #@ if val != []:
+    (@= key @):
+      #@ for item in val:
+      - (@= item @)
+      #@ end
+    #@ end
+    #@ end
+  #@ end

--- a/llama-cpp/docker-compose.yaml
+++ b/llama-cpp/docker-compose.yaml
@@ -1,0 +1,50 @@
+services:
+  llama-cpu:
+    profiles:
+      - cpu
+    image: ${LLAMA_IMAGE}:${LLAMA_IMAGE_VARIANT}
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    sysctls:
+      - net.ipv4.ip_unprivileged_port_start=1024
+
+  llama-cuda:
+    profiles:
+      - cuda
+    image: ${LLAMA_IMAGE}:${LLAMA_IMAGE_VARIANT}-cuda
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    sysctls:
+      - net.ipv4.ip_unprivileged_port_start=1024
+    devices:
+      - nvidia.com/gpu=all
+
+  llama-rocm:
+    profiles:
+      - rocm
+    image: ${LLAMA_IMAGE}:${LLAMA_IMAGE_VARIANT}-rocm
+    restart: unless-stopped
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    security_opt:
+      - seccomp=unconfined
+      - no-new-privileges:true
+    group_add:
+      - video
+      - render
+    cap_drop:
+      - ALL
+    sysctls:
+      - net.ipv4.ip_unprivileged_port_start=1024
+    environment:
+      - HSA_OVERRIDE_GFX_VERSION=${LLAMA_HSA_OVERRIDE_GFX_VERSION}
+
+volumes:
+  llama:

--- a/llama-cpp/llama-add-models
+++ b/llama-cpp/llama-add-models
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+## llama-add-models SERVICE [HF_TOKEN] [ENV_FILE]
+## Prompts user for HuggingFace model identifiers or direct URLs,
+## then downloads .gguf files directly into /models/ in the running container.
+
+BIN=$(dirname ${BASH_SOURCE})
+ROOT_DIR="${ROOT_DIR:-$(dirname ${BIN})}"
+source ${ROOT_DIR}/_scripts/funcs.sh
+set -eo pipefail
+
+SERVICE="${1}"
+HF_TOKEN="${2:-}"
+ENV_FILE="${3:-}"
+
+if [[ -z "${SERVICE}" ]]; then
+    fault "Usage: llama-add-models SERVICE [HF_TOKEN] [ENV_FILE]"
+fi
+
+COMPOSE="docker compose"
+if [[ -n "${ENV_FILE}" ]]; then
+    COMPOSE="docker compose --env-file ${ENV_FILE}"
+fi
+
+# Verify the service is running
+running_services=$(${COMPOSE} ps --format json 2>/dev/null || true)
+if [[ -z "${running_services}" ]]; then
+    fault "Service '${SERVICE}' is not running. Start it first with 'make install'."
+fi
+
+# Handle both array output (multiple containers) and single object output
+service_found=false
+if echo "${running_services}" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    if echo "${running_services}" | jq -r '.[].Name' 2>/dev/null | grep -q "${SERVICE}"; then
+        service_found=true
+    fi
+else
+    if echo "${running_services}" | jq -r '.Name' 2>/dev/null | grep -q "${SERVICE}"; then
+        service_found=true
+    fi
+fi
+
+if [[ "${service_found}" != "true" ]]; then
+    fault "Service '${SERVICE}' is not running. Start it first with 'make install'."
+fi
+
+compose_exec() {
+    ${COMPOSE} exec -T "${SERVICE}" "$@"
+}
+
+download_from_url() {
+    local url="$1"
+    local filename
+    filename=$(basename "$url" | sed 's/[?#].*//')
+    
+    if [[ -z "${filename}" ]]; then
+        fault "Could not determine filename from URL: ${url}"
+    fi
+    
+    # Check if model already exists
+    if compose_exec test -f "/models/${filename}" 2>/dev/null; then
+        local size
+        size=$(compose_exec stat -c%s "/models/${filename}" 2>/dev/null || echo 0)
+        local human_size
+        human_size=$(compose_exec numfmt --to=iec-i --suffix=B "${size}" 2>/dev/null || echo "${size} bytes")
+        echo "⚠ ${filename} already exists (${human_size})."
+        confirm n "Re-download and overwrite?" || return 0
+    fi
+    
+    echo "Downloading ${filename} to /models/..."
+    
+    local curl_cmd="curl -L -f --progress-bar"
+    if [[ -n "${HF_TOKEN}" ]]; then
+        curl_cmd="${curl_cmd} -H 'Authorization: Bearer ${HF_TOKEN}'"
+    fi
+    curl_cmd="${curl_cmd} -o /models/${filename} '${url}'"
+    
+    compose_exec bash -c "${curl_cmd}"
+    
+    # Verify the file exists and show size
+    local size
+    size=$(compose_exec stat -c%s "/models/${filename}" 2>/dev/null || echo "0")
+    if [[ "${size}" == "0" ]]; then
+        fault "Download failed: /models/${filename}"
+    fi
+    
+    local human_size
+    human_size=$(compose_exec numfmt --to=iec-i --suffix=B "${size}" 2>/dev/null || echo "${size} bytes")
+    echo "✓ Downloaded: ${filename} (${human_size})"
+}
+
+download_from_hf() {
+    local repo="$1"
+    local filename="$2"
+    
+    if [[ -z "${filename}" ]]; then
+        # Query HF API for available .gguf files
+        echo "Fetching available .gguf files from ${repo}..."
+        
+        local api_url="https://huggingface.co/api/models/${repo}/tree/main"
+        local curl_opts="-s"
+        if [[ -n "${HF_TOKEN}" ]]; then
+            curl_opts="${curl_opts} -H 'Authorization: Bearer ${HF_TOKEN}'"
+        fi
+        
+        local file_list
+        file_list=$(curl ${curl_opts} "${api_url}" | jq -r '.[].path' | grep '\.gguf$' || true)
+        
+        if [[ -z "${file_list}" ]]; then
+            fault "No .gguf files found in ${repo}"
+        fi
+        
+        # Present options to user
+        readarray -t options <<< "${file_list}"
+        
+        if [[ ${#options[@]} -eq 1 ]]; then
+            filename="${options[0]}"
+            echo "Found single .gguf file: ${filename}"
+        else
+            echo "Available .gguf files:"
+            local i=1
+            for opt in "${options[@]}"; do
+                echo "  ${i}) ${opt}"
+                i=$((i + 1))
+            done
+            echo ""
+            read -e -p "Select a file (number): " selection
+            if [[ "${selection}" =~ ^[0-9]+$ ]] && [[ ${selection} -ge 1 ]] && [[ ${selection} -le ${#options[@]} ]]; then
+                filename="${options[$((selection - 1))]}"
+            else
+                fault "Invalid selection: ${selection}"
+            fi
+        fi
+    fi
+    
+    local url="https://huggingface.co/${repo}/resolve/main/${filename}"
+    download_from_url "${url}"
+}
+
+echo "=== llama.cpp Model Downloader ==="
+echo "Models will be downloaded directly into /models/ in the '${SERVICE}' container."
+echo ""
+
+while true; do
+    echo ""
+    read -e -p "Enter model source (URL, HF user/repo:file, or HF user/repo), or blank to finish: " source
+    
+    # Blank input = done
+    if [[ -z "${source}" ]]; then
+        break
+    fi
+    
+    if [[ "${source}" =~ ^https?:// ]]; then
+        # Direct URL
+        download_from_url "${source}"
+    elif [[ "${source}" == *":"* ]]; then
+        # HF identifier with filename: user/repo:filename
+        local_repo="${source%%:*}"
+        local_filename="${source#*:}"
+        download_from_hf "${local_repo}" "${local_filename}"
+    else
+        # HF identifier without filename: user/repo
+        download_from_hf "${source}" ""
+    fi
+done
+
+echo ""
+echo "All downloads complete."

--- a/llama-cpp/llama-delete-models
+++ b/llama-cpp/llama-delete-models
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+## llama-delete-models SERVICE [ENV_FILE]
+## Lists all .gguf model files in /models/, lets user select 1 or more to delete.
+
+BIN=$(dirname ${BASH_SOURCE})
+ROOT_DIR="${ROOT_DIR:-$(dirname ${BIN})}"
+source ${ROOT_DIR}/_scripts/funcs.sh
+set -eo pipefail
+
+SERVICE="${1}"
+ENV_FILE="${2:-}"
+
+if [[ -z "${SERVICE}" ]]; then
+    fault "Usage: llama-delete-models SERVICE [ENV_FILE]"
+fi
+
+COMPOSE="docker compose"
+if [[ -n "${ENV_FILE}" ]]; then
+    COMPOSE="docker compose --env-file ${ENV_FILE}"
+fi
+
+# Verify the service is running
+running_services=$(${COMPOSE} ps --format json 2>/dev/null || true)
+if [[ -z "${running_services}" ]]; then
+    fault "Service '${SERVICE}' is not running. Start it first with 'make install'."
+fi
+
+# Handle both array output (multiple containers) and single object output
+service_found=false
+if echo "${running_services}" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    if echo "${running_services}" | jq -r '.[].Name' 2>/dev/null | grep -q "${SERVICE}"; then
+        service_found=true
+    fi
+else
+    if echo "${running_services}" | jq -r '.Name' 2>/dev/null | grep -q "${SERVICE}"; then
+        service_found=true
+    fi
+fi
+
+if [[ "${service_found}" != "true" ]]; then
+    fault "Service '${SERVICE}' is not running. Start it first with 'make install'."
+fi
+
+# Get list of .gguf files
+readarray -t models < <(${COMPOSE} exec -T "${SERVICE}" bash -c '
+    shopt -s nullglob
+    files=(/models/*.gguf)
+    if [[ ${#files[@]} -gt 0 ]]; then
+        for f in "${files[@]}"; do
+            size=$(stat -c%s "$f" 2>/dev/null || echo 0)
+            human=$(numfmt --to=iec-i --suffix=B "$size" 2>/dev/null || echo "$size bytes")
+            echo "$(basename "$f") (${human})"
+        done
+    fi
+')
+
+if [[ ${#models[@]} -eq 0 ]]; then
+    echo "No .gguf models found in /models/."
+    exit 0
+fi
+
+echo "=== Models in /models/ ==="
+echo ""
+
+# Present selection menu
+echo "Select models to delete (space to toggle, enter to confirm):"
+echo ""
+
+# Use script-wizard select for multi-selection
+readarray -t selected < <(wizard select "Select models to delete:" "${models[@]}")
+
+if [[ ${#selected[@]} -eq 0 ]]; then
+    echo "No models selected for deletion."
+    exit 0
+fi
+
+echo ""
+echo "The following model(s) will be deleted:"
+for model in "${selected[@]}"; do
+    echo "  - ${model}"
+done
+echo ""
+
+# Confirm deletion
+confirm n "Delete ${#selected[@]} model(s)?"
+
+# Check for corresponding .json config files
+json_files=()
+for model in "${selected[@]}"; do
+    filename=$(echo "${model}" | sed 's/ (.*$//')
+    model_id="${filename%.gguf}"
+    json_file="${model_id}.json"
+    if ${COMPOSE} exec -T "${SERVICE}" test -f "/models/${json_file}" 2>/dev/null; then
+        json_files+=("${json_file}")
+    fi
+done
+
+# Ask about deleting .json files if any exist
+json_files_to_delete=()
+if [[ ${#json_files[@]} -gt 0 ]]; then
+    echo ""
+    echo "Select config file(s) to delete (space to toggle, enter to confirm):"
+    echo ""
+    # Pre-select all config files using --default with JSON array format
+    json_files_default=$(array_to_json "${json_files[@]}")
+    readarray -t json_files_to_delete < <(wizard select --default "$json_files_default" "Select config files to delete:" "${json_files[@]}")
+fi
+
+deleted=0
+deleted_json=0
+for model in "${selected[@]}"; do
+    # Extract just the filename (before the size info in parens)
+    filename=$(echo "${model}" | sed 's/ (.*$//')
+    echo "Deleting ${filename}..."
+    ${COMPOSE} exec -T "${SERVICE}" rm -f "/models/${filename}"
+    deleted=$((deleted + 1))
+done
+
+# Delete selected .json files
+if [[ ${#json_files_to_delete[@]} -gt 0 ]]; then
+    for json_file in "${json_files_to_delete[@]}"; do
+        echo "Deleting ${json_file}..."
+        ${COMPOSE} exec -T "${SERVICE}" rm -f "/models/${json_file}"
+        deleted_json=$((deleted_json + 1))
+    done
+fi
+
+echo ""
+echo "✓ Deleted ${deleted} model(s)."
+if [[ ${#json_files_to_delete[@]} -gt 0 ]]; then
+    echo "✓ Deleted ${deleted_json} config file(s)."
+fi

--- a/llama-cpp/llama-list-models
+++ b/llama-cpp/llama-list-models
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+## llama-list-models SERVICE [ENV_FILE] [--json]
+## Lists models available in the running llama.cpp container.
+## Default: simple list, one per line: "<model name> (<model id>)"
+## With --json: full JSON output from the API.
+
+BIN=$(dirname ${BASH_SOURCE})
+ROOT_DIR="${ROOT_DIR:-$(dirname ${BIN})}"
+source ${ROOT_DIR}/_scripts/funcs.sh
+set -eo pipefail
+
+SERVICE=""
+ENV_FILE=""
+JSON_OUTPUT=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --json)
+            JSON_OUTPUT=true
+            ;;
+        *)
+            if [[ -z "${SERVICE}" ]]; then
+                SERVICE="$arg"
+            elif [[ -z "${ENV_FILE}" ]]; then
+                ENV_FILE="$arg"
+            else
+                fault "Usage: llama-list-models SERVICE [ENV_FILE] [--json]"
+            fi
+            ;;
+    esac
+done
+
+if [[ -z "${SERVICE}" ]]; then
+    fault "Usage: llama-list-models SERVICE [ENV_FILE] [--json]"
+fi
+
+COMPOSE="docker compose"
+if [[ -n "${ENV_FILE}" ]]; then
+    COMPOSE="docker compose --env-file ${ENV_FILE}"
+fi
+
+# Verify the service is running
+running_services=$(${COMPOSE} ps --format json 2>/dev/null || true)
+if [[ -z "${running_services}" ]]; then
+    fault "Service '${SERVICE}' is not running. Start it first with 'make install'."
+fi
+
+# Handle both array output (multiple containers) and single object output
+service_found=false
+if echo "${running_services}" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    if echo "${running_services}" | jq -r '.[].Name' 2>/dev/null | grep -q "${SERVICE}"; then
+        service_found=true
+    fi
+else
+    if echo "${running_services}" | jq -r '.Name' 2>/dev/null | grep -q "${SERVICE}"; then
+        service_found=true
+    fi
+fi
+
+if [[ "${service_found}" != "true" ]]; then
+    fault "Service '${SERVICE}' is not running. Start it first with 'make install'."
+fi
+
+if [[ "${JSON_OUTPUT}" == "true" ]]; then
+    # Fetch models from the API for JSON output
+    models_json=$(${COMPOSE} exec -T "${SERVICE}" curl -s http://localhost:8080/v1/models 2>/dev/null || true)
+    if [[ -z "${models_json}" ]]; then
+        fault "Could not query the API. Is the server running?"
+    fi
+    echo "${models_json}" | jq '.'
+else
+    # List from filesystem (ground truth of available models)
+    ${COMPOSE} exec -T "${SERVICE}" bash -c '
+        shopt -s nullglob
+        files=(/models/*.gguf)
+        if [[ ${#files[@]} -gt 0 ]]; then
+            for f in "${files[@]}"; do
+                basename_f=$(basename "$f")
+                model_id="${basename_f%.gguf}"
+                size_bytes=$(stat -c %s "$f")
+                if (( size_bytes >= 1073741824 )); then
+                    size_human=$(awk "BEGIN {printf \"%.2f GB\", ${size_bytes}/1073741824}")
+                elif (( size_bytes >= 1048576 )); then
+                    size_human=$(awk "BEGIN {printf \"%.2f MB\", ${size_bytes}/1048576}")
+                else
+                    size_human=$(awk "BEGIN {printf \"%.2f KB\", ${size_bytes}/1024}")
+                fi
+                echo "${basename_f} (${model_id}) - ${size_human}"
+            done
+        else
+            echo "(no .gguf files found)"
+        fi
+    '
+fi

--- a/llama-cpp/llama-manage-model-configs
+++ b/llama-cpp/llama-manage-model-configs
@@ -1,0 +1,223 @@
+#!/bin/bash
+
+## llama-manage-model-configs SERVICE [ENV_FILE]
+## Interactive editor for per-model JSON configuration files.
+## Allows editing model-specific settings like context size, threads, GPU layers, etc.
+
+BIN=$(dirname ${BASH_SOURCE})
+ROOT_DIR="${ROOT_DIR:-$(dirname ${BIN})}"
+source ${ROOT_DIR}/_scripts/funcs.sh
+set -eo pipefail
+
+SERVICE="${1}"
+ENV_FILE="${2:-}"
+
+if [[ -z "${SERVICE}" ]]; then
+    fault "Usage: llama-manage-model-configs SERVICE [ENV_FILE]"
+fi
+
+COMPOSE="docker compose"
+if [[ -n "${ENV_FILE}" ]]; then
+    COMPOSE="docker compose --env-file ${ENV_FILE}"
+    DOTENV="${BIN}/dotenv -f ${ENV_FILE} get"
+else
+    DOTENV="${BIN}/dotenv get"
+fi
+
+# Verify the service is running
+running_services=$(${COMPOSE} ps --format json 2>/dev/null || true)
+if [[ -z "${running_services}" ]]; then
+    fault "Service '${SERVICE}' is not running. Start it first with 'make install'."
+fi
+
+# Handle both array output (multiple containers) and single object output
+service_found=false
+if echo "${running_services}" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    if echo "${running_services}" | jq -r '.[].Name' 2>/dev/null | grep -q "${SERVICE}"; then
+        service_found=true
+    fi
+else
+    if echo "${running_services}" | jq -r '.Name' 2>/dev/null | grep -q "${SERVICE}"; then
+        service_found=true
+    fi
+fi
+
+if [[ "${service_found}" != "true" ]]; then
+    fault "Service '${SERVICE}' is not running. Start it first with 'make install'."
+fi
+
+# Get API token if set
+API_TOKEN=$(${DOTENV} LLAMA_API_TOKEN 2>/dev/null || true)
+CURL_AUTH=()
+if [[ -n "${API_TOKEN}" ]]; then
+    CURL_AUTH=(-H "x-api-key: ${API_TOKEN}")
+fi
+
+# Get server port
+SERVER_PORT=$(${DOTENV} LLAMA_SERVER_PORT 2>/dev/null || echo "8080")
+
+# Get .env defaults for template
+ENV_N_GPU_LAYERS=$(${DOTENV} LLAMA_N_GPU_LAYERS 2>/dev/null || true)
+ENV_CONTEXT_LENGTH=$(${DOTENV} LLAMA_CONTEXT_LENGTH 2>/dev/null || true)
+
+# Default values if .env is blank
+DEFAULT_THREADS=8
+DEFAULT_GPU_LAYERS="${ENV_N_GPU_LAYERS:-99}"
+DEFAULT_CONTEXT="${ENV_CONTEXT_LENGTH:-8096}"
+
+# Get list of .gguf files
+readarray -t models < <(${COMPOSE} exec -T "${SERVICE}" bash -c '
+    shopt -s nullglob
+    files=(/models/*.gguf)
+    if [[ ${#files[@]} -gt 0 ]]; then
+        for f in "${files[@]}"; do
+            size=$(stat -c%s "$f" 2>/dev/null || echo 0)
+            human=$(numfmt --to=iec-i --suffix=B "$size" 2>/dev/null || echo "$size bytes")
+            echo "$(basename "$f") (${human})"
+        done
+    fi
+')
+
+if [[ ${#models[@]} -eq 0 ]]; then
+    echo "No .gguf models found in /models/."
+    exit 0
+fi
+
+echo "=== Manage Model Configurations ==="
+echo ""
+
+# Use script-wizard choose for single selection
+selected=$(wizard choose "Select a model to configure:" "${models[@]}")
+
+if [[ -z "${selected}" ]]; then
+    echo "No selection made. Exiting."
+    exit 0
+fi
+
+# Extract just the filename (before the size info in parens)
+model_filename=$(echo "${selected}" | sed 's/ (.*$//')
+model_id="${model_filename%.gguf}"
+json_filename="${model_id}.json"
+
+echo ""
+echo "Managing configuration for: ${model_filename}"
+echo "Config file: ${json_filename}"
+echo ""
+
+# Create temp directory for editing
+TMPDIR=$(mktemp -d)
+trap "rm -rf ${TMPDIR}" EXIT
+
+LOCAL_JSON="${TMPDIR}/${json_filename}"
+ORIGINAL_JSON="${TMPDIR}/${json_filename}.orig"
+
+# Check if config already exists in container
+if ${COMPOSE} exec -T "${SERVICE}" test -f "/models/${json_filename}" 2>/dev/null; then
+    echo "Existing configuration found. Downloading..."
+    ${COMPOSE} exec -T "${SERVICE}" cp "/models/${json_filename}" "/tmp/${json_filename}" 2>/dev/null || true
+    ${COMPOSE} cp "${SERVICE}:/tmp/${json_filename}" "${LOCAL_JSON}" 2>/dev/null || \
+    ${COMPOSE} exec -T "${SERVICE}" cat "/models/${json_filename}" > "${LOCAL_JSON}"
+    cp "${LOCAL_JSON}" "${ORIGINAL_JSON}"
+else
+    echo "No existing configuration. Creating new one from template..."
+    cat > "${LOCAL_JSON}" <<EOF
+{
+  "model": "${model_filename}",
+  "max_context_len": ${DEFAULT_CONTEXT},
+  "context_size": ${DEFAULT_CONTEXT},
+  "threads": ${DEFAULT_THREADS},
+  "gpu_layers": ${DEFAULT_GPU_LAYERS}
+}
+EOF
+    # For new files, original is empty to ensure we detect any content
+    touch "${ORIGINAL_JSON}"
+fi
+
+# Open in editor
+EDITOR="${EDITOR:-nano}"
+echo ""
+echo "Opening ${json_filename} in ${EDITOR}..."
+echo "Edit the configuration and save when done."
+echo ""
+
+${EDITOR} "${LOCAL_JSON}"
+
+# Check if any changes were made
+if diff -q "${ORIGINAL_JSON}" "${LOCAL_JSON}" >/dev/null 2>&1; then
+    echo ""
+    echo "No changes detected. Exiting."
+    exit 0
+fi
+
+echo ""
+echo "Changes detected. Validating configuration..."
+
+# Validate JSON before uploading
+if ! jq '.' "${LOCAL_JSON}" >/dev/null 2>&1; then
+    fault "Invalid JSON in ${LOCAL_JSON}. Aborting. Please fix the JSON and try again."
+fi
+
+# Check if 'model' field matches the expected filename
+json_model_field=$(jq -r '.model // empty' "${LOCAL_JSON}" 2>/dev/null || true)
+if [[ -n "${json_model_field}" && "${json_model_field}" != "${model_filename}" ]]; then
+    echo "Warning: 'model' field in JSON (${json_model_field}) does not match selected model (${model_filename})."
+    confirm n "Continue anyway" "?" || fault "Aborted."
+fi
+
+# Upload the config back to the container
+echo ""
+echo "Uploading configuration to container..."
+${COMPOSE} exec -T "${SERVICE}" bash -c "cat > /models/${json_filename}" < "${LOCAL_JSON}"
+
+echo "Configuration saved to /models/${json_filename} in the container."
+
+# Check if the model is currently loaded
+echo ""
+echo "Checking if model is currently loaded..."
+loaded_models=$(${COMPOSE} exec -T "${SERVICE}" curl -s "${CURL_AUTH[@]}" "http://localhost:${SERVER_PORT}/v1/models" 2>/dev/null || true)
+
+if [[ -z "${loaded_models}" ]]; then
+    echo "Could not query the API. Model config has been saved."
+    echo "To apply the new configuration, unload and reload the model manually."
+    exit 0
+fi
+
+# Check if our model is in the list and get its status
+model_status=$(echo "${loaded_models}" | jq -r '.data[]? | select(.id == "'"${model_id}"'" or .id == "'"${model_filename}"'") | .status.value' 2>/dev/null || true)
+
+if [[ "${model_status}" == "loaded" ]]; then
+    echo "Model is currently loaded. Reloading to apply new configuration..."
+    
+    # Unload the model
+    echo "Unloading ${model_filename}..."
+    unload_result=$(${COMPOSE} exec -T "${SERVICE}" curl -s -X POST "${CURL_AUTH[@]}" \
+        -H "Content-Type: application/json" \
+        -d "{\"model\": \"${model_id}\"}" \
+        "http://localhost:${SERVER_PORT}/models/unload" 2>/dev/null || true)
+    
+    if echo "${unload_result}" | jq -e '.success == true' >/dev/null 2>&1; then
+        echo "Model unloaded successfully."
+    else
+        echo "Warning: Unload may have failed. Response: ${unload_result}"
+    fi
+    
+    # Load the model
+    echo "Loading ${model_filename}..."
+    load_result=$(${COMPOSE} exec -T "${SERVICE}" curl -s -X POST "${CURL_AUTH[@]}" \
+        -H "Content-Type: application/json" \
+        -d "{\"model\": \"${model_id}\"}" \
+        "http://localhost:${SERVER_PORT}/models/load" 2>/dev/null || true)
+    
+    if echo "${load_result}" | jq -e '.success == true' >/dev/null 2>&1; then
+        echo "Model loaded successfully with new configuration."
+    else
+        echo "Warning: Load may have failed. Response: ${load_result}"
+        echo "You may need to manually reload the model."
+    fi
+else
+    echo "Model is not currently loaded. Configuration saved."
+    echo "The new configuration will take effect when the model is next loaded."
+fi
+
+echo ""
+echo "Done."


### PR DESCRIPTION
Add a llama.cpp service.

`llama-server` provides an OpenAI-compatible API for serving GGUF models, as well as a web app for basic LLM chatting.

d.rymcg.tech already has Ollama and vLLM. I'm adding this because I want an alternative to Ollama (because [reasons](https://sleepingrobots.com/dreams/stop-using-ollama/)), and vLLM doesn't offer easy model management (well, not as easy as switching models from the UI or an API endpoint).Add a llama.cpp service.

Resolves #618 