### PR TITLE
Add NATS sub-project with Step-CA mTLS, JetStream, and per-user auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Install these applications at your preference:
 * [Minio](minio#readme) - an S3 storage server
 * [Mopidy](mopidy#readme) - a streaming music server built with MPD and Snapcast
 * [Mosquitto](mosquitto#readme) - an MQTT server
+* [NATS](nats#readme) - a messaging system designed for building modern distributed systems
 * [Nextcloud](nextcloud#readme) - a collaborative file server
 * [Nginx](nginx#readme) - a webserver configured with fast-cgi support for PHP scripts
 * [Node-RED](nodered#readme) - a graphical event pipeline editor

--- a/nats/.env-dist
+++ b/nats/.env-dist
@@ -1,0 +1,49 @@
+NATS_IMAGE=nats:2.12-alpine
+NATS_STEP_CLI_IMAGE=smallstep/step-cli:latest
+
+# Domain name for the NATS server (used for TLS certificate CN):
+NATS_TRAEFIK_HOST=nats.example.com
+
+NATS_INSTANCE=
+NATS_INSTANCE_PROTECTION=false
+
+# NATS cluster/server name:
+NATS_CLUSTER_NAME=nats
+
+# Host port to expose for NATS client connections (TLS/mTLS):
+NATS_CLIENT_PORT=4222
+
+# Enable JetStream (provides persistence, KV store, object store, streams):
+NATS_JETSTREAM_ENABLE=false
+
+# Per-user subject authorization.
+# Clients always need a valid TLS certificate signed by the CA to connect.
+# Format: CN:publish_subjects:subscribe_subjects (semicolon-separated entries)
+# Subjects within each field are comma-separated. Use ">" for all subjects.
+# Leave publish or subscribe empty to deny that action.
+#
+# Examples:
+#   Full access:     foo.clients.nats.example.com:>:>
+#   Pub+Sub specific: foo.clients.nats.example.com:sensors.>,devices.>:sensors.>,devices.>
+#   Subscribe only:  bar.clients.nats.example.com::sensors.>,devices.>
+#   Publish only:    baz.clients.nats.example.com:events.>:
+#
+# Multiple users separated by semicolons:
+#   foo.clients.nats.example.com:>:>;bar.clients.nats.example.com::sensors.>
+NATS_AUTH_USERS=
+
+# Step-CA configuration for mTLS:
+NATS_STEP_CA_URL=
+NATS_STEP_CA_FINGERPRINT=
+
+# One-time-use token from Step-CA server:
+# (Only used the first time the container volume is created.
+# Usually expires 30m after the server issues it.
+# If reinstalling, generate a new token first.)
+NATS_STEP_CA_TOKEN=
+
+# Client certificate expiration (hours):
+NATS_CLIENT_CERT_EXPIRATION_HOURS=2160
+
+# META:
+# PREFIX=NATS

--- a/nats/Makefile
+++ b/nats/Makefile
@@ -1,0 +1,165 @@
+ROOT_DIR = ..
+include ${ROOT_DIR}/_scripts/Makefile.projects
+include ${ROOT_DIR}/_scripts/Makefile.instance
+
+STEP=step-cli
+
+.PHONY: config-hook
+config-hook:
+	@${BIN}/reconfigure_ask ${ENV_FILE} NATS_TRAEFIK_HOST "Enter the NATS domain name" nats${INSTANCE_URL_SUFFIX}.${ROOT_DOMAIN}
+	@${BIN}/reconfigure ${ENV_FILE} NATS_INSTANCE=$${instance:-default}
+	@${BIN}/reconfigure ${ENV_FILE} NATS_CLUSTER_NAME=$${instance:-default}
+	@${BIN}/reconfigure_ask ${ENV_FILE} NATS_CLIENT_PORT "Enter the NATS client port to expose" 4222
+	@${BIN}/confirm $$(test "$$(${BIN}/dotenv -f ${ENV_FILE} get NATS_JETSTREAM_ENABLE)" == "true" && echo "yes" || echo "no") "Do you want to enable JetStream (persistence, KV store, streams)" "?" && ${BIN}/reconfigure ${ENV_FILE} NATS_JETSTREAM_ENABLE=true || ${BIN}/reconfigure ${ENV_FILE} NATS_JETSTREAM_ENABLE=false
+	@${BIN}/reconfigure_ask ${ENV_FILE} NATS_STEP_CA_URL "Enter the Step-CA URL" $$(cat $$(${STEP} path)/config/defaults.json | jq -r '."ca-url"')
+	@echo
+	@echo "Retrieving Step-CA fingerprint from $$(${BIN}/dotenv -f ${ENV_FILE} get NATS_STEP_CA_URL)/roots.pem ..."
+	@${BIN}/reconfigure_ask ${ENV_FILE} NATS_STEP_CA_FINGERPRINT "VERIFY the Step-CA fingerprint" $$(${STEP} ca root | ${STEP} certificate fingerprint)
+	@make --no-print-directory auth-users
+	@EXISTING_TOKEN=$$(${BIN}/dotenv -f ${ENV_FILE} get NATS_STEP_CA_TOKEN); \
+	if [[ -n "$${EXISTING_TOKEN}" ]]; then \
+		echo "Existing NATS_STEP_CA_TOKEN found."; \
+		if ! ${BIN}/confirm no "Do you want to request a new Step-CA token (requires Step-CA credentials)" "?"; then \
+			echo "Keeping existing Step-CA token."; \
+			exit 0; \
+		fi; \
+	fi; \
+	${BIN}/reconfigure ${ENV_FILE} NATS_STEP_CA_TOKEN="" &>/dev/null; \
+	echo "Retrieving one-time-use token from Step-CA server."; \
+	echo "Get ready to enter your root Step-CA credentials!"; \
+	echo; \
+	${BIN}/reconfigure ${ENV_FILE} NATS_STEP_CA_TOKEN="$$(step-cli ca token $$(${BIN}/dotenv -f ${ENV_FILE} get NATS_TRAEFIK_HOST) --provisioner admin)"
+
+.PHONY: auth-users
+auth-users:
+	@NATS_TRAEFIK_HOST=$$(${BIN}/dotenv -f ${ENV_FILE} get NATS_TRAEFIK_HOST); \
+	CURRENT=$$(${BIN}/dotenv -f ${ENV_FILE} get NATS_AUTH_USERS); \
+	if [[ -n "$${CURRENT}" ]]; then \
+		IFS=';' read -ra ENTRIES <<< "$${CURRENT}"; \
+	else \
+		ENTRIES=(); \
+	fi; \
+	while true; do \
+		echo; \
+		echo "## NATS Authorization Users"; \
+		if [[ $${#ENTRIES[@]} -gt 0 ]]; then \
+			for i in "$${!ENTRIES[@]}"; do \
+				IFS=':' read -r cn pub sub <<< "$${ENTRIES[$$i]}"; \
+				echo "  $$((i+1)). $${cn}  publish=[$${pub:-DENY}] subscribe=[$${sub:-DENY}]"; \
+			done; \
+		else \
+			echo "  No users configured (all access denied)."; \
+		fi; \
+		echo; \
+		ACTION=$$(eval "${BIN}/script-wizard choose 'Manage auth users' 'done' 'add' 'edit' 'remove' --default 'done'") || break; \
+		if [[ -z "$${ACTION}" || "$${ACTION}" == "done" ]]; then \
+			break; \
+		elif [[ "$${ACTION}" == "add" ]]; then \
+			CN=$$(${BIN}/ask_echo "Enter client CN (domain)" "$${HOSTNAME}.clients.$${NATS_TRAEFIK_HOST}"); \
+			MODE=$$(eval "${BIN}/script-wizard choose 'Permission mode' 'prefix' 'full' 'custom' --default 'prefix'"); \
+			if [[ "$${MODE}" == "full" ]]; then \
+				PUB=">"; \
+				SUB=">"; \
+			elif [[ "$${MODE}" == "prefix" ]]; then \
+				PREFIX=$$(${BIN}/ask_echo "Enter subject prefix (e.g. hookshot.d2-admin)"); \
+				KV_BUCKET=$$(echo "$${PREFIX}" | tr '.' '_')_history; \
+				ACCESS=$$(eval "${BIN}/script-wizard choose 'Access level' 'read-write' 'read-only' 'write-only' --default 'read-write'"); \
+				if [[ "$${ACCESS}" == "read-write" ]]; then \
+					PUB="$${PREFIX}.>,\$$\$$KV.$${KV_BUCKET}.>,\$$\$$JS.API.*.KV_$${KV_BUCKET},\$$\$$JS.API.*.*.KV_$${KV_BUCKET},\$$\$$JS.API.*.*.*.KV_$${KV_BUCKET}"; \
+					SUB="$${PREFIX}.>,_INBOX.>"; \
+				elif [[ "$${ACCESS}" == "read-only" ]]; then \
+					PUB="\$$\$$JS.API.*.KV_$${KV_BUCKET},\$$\$$JS.API.*.*.KV_$${KV_BUCKET},\$$\$$JS.API.*.*.*.KV_$${KV_BUCKET}"; \
+					SUB="$${PREFIX}.>,_INBOX.>"; \
+				elif [[ "$${ACCESS}" == "write-only" ]]; then \
+					PUB="$${PREFIX}.>,\$$\$$KV.$${KV_BUCKET}.>"; \
+					SUB="_INBOX.>"; \
+				fi; \
+			elif [[ "$${MODE}" == "custom" ]]; then \
+				PUB=$$(${BIN}/ask_echo_blank "Enter publish subjects (comma-separated, > for all, empty to deny)"); \
+				SUB=$$(${BIN}/ask_echo_blank "Enter subscribe subjects (comma-separated, > for all, empty to deny)"); \
+			fi; \
+			ENTRIES+=("$${CN}:$${PUB}:$${SUB}"); \
+			echo "Added: $${CN}"; \
+		elif [[ "$${ACTION}" == "edit" ]]; then \
+			if [[ $${#ENTRIES[@]} -eq 0 ]]; then \
+				echo "No users to edit."; \
+				continue; \
+			fi; \
+			CHOICES=(); \
+			for e in "$${ENTRIES[@]}"; do \
+				IFS=':' read -r cn _ _ <<< "$$e"; \
+				CHOICES+=("$${cn}"); \
+			done; \
+			EDIT_CN=$$(eval "${BIN}/script-wizard choose 'Select user to edit' $${CHOICES[@]@Q}"); \
+			for i in "$${!ENTRIES[@]}"; do \
+				IFS=':' read -r cn old_pub old_sub <<< "$${ENTRIES[$$i]}"; \
+				if [[ "$${cn}" == "$${EDIT_CN}" ]]; then \
+					MODE=$$(eval "${BIN}/script-wizard choose 'Permission mode' 'prefix' 'full' 'custom' --default 'prefix'"); \
+					if [[ "$${MODE}" == "full" ]]; then \
+						PUB=">"; \
+						SUB=">"; \
+					elif [[ "$${MODE}" == "prefix" ]]; then \
+						PREFIX=$$(${BIN}/ask_echo "Enter subject prefix (e.g. hookshot.d2-admin)"); \
+						KV_BUCKET=$$(echo "$${PREFIX}" | tr '.' '_')_history; \
+						ACCESS=$$(eval "${BIN}/script-wizard choose 'Access level' 'read-write' 'read-only' 'write-only' --default 'read-write'"); \
+						if [[ "$${ACCESS}" == "read-write" ]]; then \
+							PUB="$${PREFIX}.>,\$$\$$KV.$${KV_BUCKET}.>,\$$\$$JS.API.*.KV_$${KV_BUCKET},\$$\$$JS.API.*.*.KV_$${KV_BUCKET},\$$\$$JS.API.*.*.*.KV_$${KV_BUCKET}"; \
+							SUB="$${PREFIX}.>,_INBOX.>"; \
+						elif [[ "$${ACCESS}" == "read-only" ]]; then \
+							PUB="\$$\$$JS.API.*.KV_$${KV_BUCKET},\$$\$$JS.API.*.*.KV_$${KV_BUCKET},\$$\$$JS.API.*.*.*.KV_$${KV_BUCKET}"; \
+							SUB="$${PREFIX}.>,_INBOX.>"; \
+						elif [[ "$${ACCESS}" == "write-only" ]]; then \
+							PUB="$${PREFIX}.>,\$$\$$KV.$${KV_BUCKET}.>"; \
+							SUB="_INBOX.>"; \
+						fi; \
+					elif [[ "$${MODE}" == "custom" ]]; then \
+						PUB=$$(${BIN}/ask_echo_blank "Enter publish subjects (comma-separated, > for all, empty to deny)" "$${old_pub}"); \
+						SUB=$$(${BIN}/ask_echo_blank "Enter subscribe subjects (comma-separated, > for all, empty to deny)" "$${old_sub}"); \
+					fi; \
+					ENTRIES[$$i]="$${cn}:$${PUB}:$${SUB}"; \
+					echo "Updated: $${cn}"; \
+					break; \
+				fi; \
+			done; \
+		elif [[ "$${ACTION}" == "remove" ]]; then \
+			if [[ $${#ENTRIES[@]} -eq 0 ]]; then \
+				echo "No users to remove."; \
+				continue; \
+			fi; \
+			CHOICES=(); \
+			for e in "$${ENTRIES[@]}"; do \
+				IFS=':' read -r cn _ _ <<< "$$e"; \
+				CHOICES+=("$${cn}"); \
+			done; \
+			RM_CN=$$(eval "${BIN}/script-wizard choose 'Select user to remove' $${CHOICES[@]@Q}"); \
+			NEW_ENTRIES=(); \
+			for e in "$${ENTRIES[@]}"; do \
+				IFS=':' read -r cn _ _ <<< "$$e"; \
+				if [[ "$${cn}" != "$${RM_CN}" ]]; then \
+					NEW_ENTRIES+=("$$e"); \
+				fi; \
+			done; \
+			ENTRIES=("$${NEW_ENTRIES[@]}"); \
+			echo "Removed: $${RM_CN}"; \
+		fi; \
+	done; \
+	RESULT=$$(IFS=';'; echo "$${ENTRIES[*]}"); \
+	${BIN}/reconfigure ${ENV_FILE} NATS_AUTH_USERS="$${RESULT}"
+
+.PHONY: shell
+shell:
+	@make --no-print-directory docker-compose-shell SERVICE=nats
+
+.PHONY: cert # Create a client TLS certificate
+cert:
+	@${STEP} ca roots > certs/root_ca.crt
+	@CN=$$(${BIN}/ask_echo "Enter the client domain (CN) to be certified" ${HOSTNAME}.clients.$$(${BIN}/dotenv -f ${ENV_FILE} get NATS_TRAEFIK_HOST)); ${STEP} ca certificate "$${CN}" "certs/$${CN}.crt" "certs/$${CN}.key" --provisioner admin --not-after "$$(${BIN}/dotenv -f ${ENV_FILE} get NATS_CLIENT_CERT_EXPIRATION_HOURS)"h
+
+.PHONY: install-hook
+install-hook:
+	@echo "Restarting NATS to pick up config changes ..."
+	@make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="restart nats"
+
+.PHONY: install-hook-pre
+install-hook-pre:
+	@echo

--- a/nats/README.md
+++ b/nats/README.md
@@ -1,0 +1,299 @@
+# NATS
+
+[NATS](https://nats.io/) is a high-performance messaging system for
+cloud native applications, IoT, and microservices architectures. This
+is a hardened configuration that uses Mutual TLS with
+[Step-CA](../step-ca).
+
+Example use cases:
+
+ * Pub/sub messaging between microservices
+ * Request/reply communication patterns
+ * Event streaming and data pipelines
+ * Use it in combination with [node-red](../nodered) for task
+   automation
+
+## Deploy Step-CA
+
+This configuration of NATS requires Mutual TLS:
+
+ * Follow the [Step-CA README](../step-ca) to `config` and `install`
+   your CA server (it does not need to be on the same machine, but it
+   can be).
+ * When configuring Step-CA, set
+   `STEP_CA_AUTHORITY_POLICY_X509_ALLOW_DNS` to list your allowed
+   domains:
+
+   * Include the domain of the NATS server, e.g., `nats.example.com`
+     (this could also be a wildcard if you have other services that
+     need certificates too.)
+   * Include the wildcard domain for the NATS clients, e.g.,
+     `*.clients.nats.example.com`
+   * For example:
+     `STEP_CA_AUTHORITY_POLICY_X509_ALLOW_DNS=nats.example.com,*.clients.nats.example.com`
+
+ * Come back here as soon as you have run the Step-CA `make install`
+   command. This README will give you the instructions specific to
+   NATS.
+ * ACME is not required for this scenario (one-time-use API tokens
+   will be issued instead).
+
+Your workstation needs to have the
+[step-cli](https://smallstep.com/docs/step-cli/installation/) tool
+installed (use your package manager), and it needs to be bootstrapped
+to connect to your Step-CA server instance:
+
+```
+## Use either method:
+
+## Method 1: use the step-ca Makefile target:
+## (you may have already done this if you installed Step-CA from the same workstation)
+d.rymcg.tech make step-ca client-bootstrap
+
+## Method 2: if you want to do it manually from a new machine:
+FINGERPRINT=$(curl -sk https://ca.example.com/roots.pem | \
+  docker run --rm -i smallstep/step-cli step certificate fingerprint -)
+step-cli ca bootstrap --ca-url https://ca.example.com --fingerprint ${FINGERPRINT}
+
+## Check the status (should print 'ok'):
+step-cli health
+```
+
+## Config
+
+Run:
+
+```
+make config
+```
+
+Set:
+
+ * `NATS_TRAEFIK_HOST` the external domain name (e.g.,
+   `nats.example.com`). This is used as the TLS certificate CN.
+ * `NATS_CLUSTER_NAME` the NATS server/cluster name (default: `nats`).
+ * `NATS_CLIENT_PORT` the host port for NATS client connections
+   (default: `4222`).
+ * `NATS_STEP_CA_URL` the root URL of your Step-CA instance
+   (e.g., `https://ca.example.com`)
+ * `NATS_STEP_CA_FINGERPRINT` the Step-CA fingerprint will be
+   retrieved automatically from the URL you supplied. You should
+   verify it is correct (use Step-CA's `make inspect-fingerprint`).
+ * The `NATS_STEP_CA_TOKEN` is the one-time-use token that you
+   need to get from Step-CA to request a new server certificate. It
+   will be automatically set, but you will need to enter your root
+   Step-CA credentials to get it.
+
+## Configure authorization
+
+Per-user subject authorization is configured via the `NATS_AUTH_USERS`
+env var. With `verify_and_map`, NATS maps the client certificate's SAN
+DNS name (e.g., `foo.clients.nats.example.com`) to a NATS user entry.
+
+Run `make auth-users` to interactively manage authorized users (this
+is also called during `make config`). You can add, edit, and remove
+users with an interactive menu.
+
+When adding or editing a user, you choose a permission mode:
+
+ * **prefix** (default) — Enter a NATS subject prefix (e.g.
+   `hookshot.d2-admin`). The tool auto-generates publish and subscribe
+   permissions for all subjects under that prefix, plus JetStream KV
+   permissions for the corresponding history bucket.
+ * **full** — Grants `>` (all subjects) for both publish and
+   subscribe. Use for admin clients.
+ * **custom** — Manually enter comma-separated publish and subscribe
+   subjects (the original behavior).
+
+The `NATS_AUTH_USERS` format is:
+
+```
+NATS_AUTH_USERS=CN:publish_subjects:subscribe_subjects;CN2:pub:sub
+```
+
+ * Entries separated by semicolons
+ * Each entry: `CN:publish:subscribe`
+ * Subjects within each field are comma-separated
+ * Use `>` for all subjects
+ * Leave publish or subscribe empty to deny that action
+ * Empty `NATS_AUTH_USERS` = deny all (no users configured)
+
+Examples:
+
+```
+## Full access for one user:
+NATS_AUTH_USERS=foo.clients.nats.example.com:>:>
+
+## Multiple users with different permissions:
+NATS_AUTH_USERS=foo.clients.nats.example.com:>:>;bar.clients.nats.example.com::sensors.>
+
+## Publish only (no subscribe):
+NATS_AUTH_USERS=baz.clients.nats.example.com:events.>:
+```
+
+Unlisted users (those with a valid certificate but no entry in
+`NATS_AUTH_USERS`) are denied all access by default.
+
+All users are configured with `allow_responses: true`, which permits
+NATS to deliver request-reply responses without needing explicit
+subscribe permissions on inbox subjects.
+
+Be aware that NATS clients receive no error when publishing to a
+denied subject — the message is silently dropped. Similarly,
+subscribing to a denied subject will succeed but no messages will be
+received.
+
+### JetStream and KV store permissions
+
+When JetStream is enabled (`NATS_JETSTREAM_ENABLE=true`), the
+publish/subscribe permissions also control access to JetStream
+streams, KV buckets, and object stores. NATS implements these features
+on top of regular subjects, so the same authorization model applies.
+
+All JetStream and KV operations are **publish** requests with
+responses delivered via `allow_responses`:
+
+ * **KV put/delete** requires **publish** on `$KV.BUCKET_NAME.>`
+ * **KV get** requires **publish** on `$JS.API.DIRECT.GET.KV_BUCKET_NAME`
+   (or broader `$JS.API.*.KV_BUCKET_NAME`)
+ * **Bucket create/update/info** requires **publish** on
+   `$JS.API.STREAM.*.KV_BUCKET_NAME` (or broader `$JS.API.*.*.KV_BUCKET_NAME`)
+
+The **prefix** permission mode in `make auth-users` generates all of
+these automatically. For example, with prefix `hookshot.d2-admin`:
+
+```
+publish:   hookshot.d2-admin.>, $KV.hookshot_d2-admin_history.>,
+           $JS.API.*.KV_hookshot_d2-admin_history,
+           $JS.API.*.*.KV_hookshot_d2-admin_history
+subscribe: hookshot.d2-admin.>
+```
+
+For full JetStream and KV access, use the **full** permission mode
+(`>` for both publish and subscribe).
+
+## Install
+
+Run:
+
+```
+make install
+```
+
+## Check logs
+
+Run:
+
+```
+make logs
+```
+
+Make sure you see the `step-cli` container issue the certificate:
+
+```
+### Example log excerpt showing certificate exists:
+step-cli-1   | ✔ Certificate: /home/step/certs/nats.example.com.crt
+step-cli-1   | ✔ Private Key: /home/step/certs/nats.example.com.key
+```
+
+And the `nats` container should show:
+
+```
+nats-1       | ## Found full TLS certificate chain.
+```
+
+## Create client certificates
+
+Install the [nats-cli](https://github.com/nats-io/natscli) tool on
+your workstation.
+
+Create a certificate for your NATS client:
+
+```
+make cert
+```
+
+ * Enter the `subject (CN / domain name) to be certified`: this should
+   be a unique subdomain name for your client. It can be made up, and
+   does not need DNS. Example: `foo.clients.nats.example.com`. It is
+   recommended to use your workstation hostname for the first part.
+
+## Test NATS clients
+
+Subscribe to a subject in one terminal:
+
+```
+(
+CN=foo.clients.nats.example.com
+export NATS_URL="tls://nats.example.com:4222"
+export NATS_CA=certs/root_ca.crt
+export NATS_CERT=certs/${CN}.crt
+export NATS_KEY=certs/${CN}.key
+
+nats sub test
+)
+```
+
+In a second terminal, publish a message:
+
+```
+(
+CN=foo.clients.nats.example.com
+export NATS_URL="tls://nats.example.com:4222"
+export NATS_CA=certs/root_ca.crt
+export NATS_CERT=certs/${CN}.crt
+export NATS_KEY=certs/${CN}.key
+
+nats pub test "Hello, World."
+)
+```
+
+## TLS certificate renewal
+
+The NATS server certificate is renewed automatically by the
+[step-cli](step-cli) sidecar container.
+
+Client certificates can be renewed on any machine that has
+[step-cli](https://smallstep.com/docs/step-cli/installation/)
+installed and bootstrapped to the same Step-CA server. Run this on the
+client before the certificate expires:
+
+```
+## Put this into a cronjob on the client to auto-renew:
+step-cli ca renew --force CRT_FILE KEY_FILE
+```
+
+**Important:** Renewal exchanges the current valid certificate for a
+new one. If the certificate expires before you renew it, Step-CA will
+reject the renewal and you will need to issue a fresh certificate with
+a new one-time token (via `make cert`). Set up a cronjob to renew well
+before expiration.
+
+The default client certificate expiration is 90 days
+(`NATS_CLIENT_CERT_EXPIRATION_HOURS=2160`).
+
+If you need expiration times longer than 90 days, you must also
+increase the Step-CA maximum:
+
+```
+## Set Step-CA MAX expiration to 100 years:
+d.rymcg.tech make step-ca \
+    reconfigure var=STEP_CA_AUTHORITY_CLAIMS_MAX_TLS_CERT_DURATION=876582h
+d.rymcg.tech make step-ca install
+```
+
+## Revoking a client certificate
+
+You can prevent a certificate from being renewed (passive revocation):
+
+```
+CERT=certs/foo.clients.nats.example.com.crt
+SERIAL=$(cat $CERT | \
+              step certificate inspect --format json | \
+              jq -r .serial_number)
+echo "Going to revoke cert with serial # ${SERIAL}"
+step ca revoke ${SERIAL} --provisioner admin --reason "Key compromise"
+```
+
+**Passive revocation only prevents the certificate from being renewed,
+it does NOT revoke the current certificate.**

--- a/nats/config/Dockerfile
+++ b/nats/config/Dockerfile
@@ -1,0 +1,6 @@
+FROM debian:stable-slim
+RUN apt-get -y update && apt-get install -y gettext
+COPY template/ /template/
+COPY setup.sh /template/setup.sh
+RUN chmod a+x /template/setup.sh
+CMD ["/template/setup.sh"]

--- a/nats/config/setup.sh
+++ b/nats/config/setup.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+CONFIG_DIR=/etc/nats
+CONFIG=${CONFIG_DIR}/nats.conf
+AUTHZ=${CONFIG_DIR}/authorization.conf
+
+if [[ -z "${NATS_CLUSTER_NAME}" ]]; then
+    echo "NATS_CLUSTER_NAME is empty."
+    exit 1
+fi
+
+if [[ -z "${NATS_TRAEFIK_HOST}" ]]; then
+    echo "NATS_TRAEFIK_HOST is empty."
+    exit 1
+fi
+
+echo "Creating new NATS config from template ..."
+mkdir -p ${CONFIG_DIR}
+cat /template/nats.conf | envsubst '${NATS_CLUSTER_NAME},${NATS_TRAEFIK_HOST}' > ${CONFIG}
+echo "[ ! ] GENERATED NEW CONFIG FILE ::: ${CONFIG}"
+
+generate_authorization() {
+    cat > ${AUTHZ} <<'HEADER'
+authorization {
+  default_permissions = {
+    publish: { deny: ">" }
+    subscribe: { deny: ">" }
+  }
+HEADER
+
+    if [[ -n "${NATS_AUTH_USERS}" ]]; then
+        echo "  users = [" >> ${AUTHZ}
+        IFS=';' read -ra ENTRIES <<< "${NATS_AUTH_USERS}"
+        for entry in "${ENTRIES[@]}"; do
+            IFS=':' read -r cn pub sub <<< "${entry}"
+            if [[ -z "${cn}" ]]; then
+                continue
+            fi
+            echo "    {" >> ${AUTHZ}
+            echo "      user: \"${cn}\"" >> ${AUTHZ}
+            echo "      permissions: {" >> ${AUTHZ}
+
+            # Publish permissions
+            if [[ -z "${pub}" ]]; then
+                echo "        publish: { deny: \">\" }" >> ${AUTHZ}
+            else
+                IFS=',' read -ra PUB_SUBJECTS <<< "${pub}"
+                if [[ ${#PUB_SUBJECTS[@]} -eq 1 ]]; then
+                    echo "        publish: \"${PUB_SUBJECTS[0]}\"" >> ${AUTHZ}
+                else
+                    printf -v pub_list '"%s", ' "${PUB_SUBJECTS[@]}"
+                    echo "        publish: [${pub_list%, }]" >> ${AUTHZ}
+                fi
+            fi
+
+            # Subscribe permissions
+            if [[ -z "${sub}" ]]; then
+                echo "        subscribe: { deny: \">\" }" >> ${AUTHZ}
+            else
+                IFS=',' read -ra SUB_SUBJECTS <<< "${sub}"
+                if [[ ${#SUB_SUBJECTS[@]} -eq 1 ]]; then
+                    echo "        subscribe: \"${SUB_SUBJECTS[0]}\"" >> ${AUTHZ}
+                else
+                    printf -v sub_list '"%s", ' "${SUB_SUBJECTS[@]}"
+                    echo "        subscribe: [${sub_list%, }]" >> ${AUTHZ}
+                fi
+            fi
+
+            echo "        allow_responses: true" >> ${AUTHZ}
+            echo "      }" >> ${AUTHZ}
+            echo "    }" >> ${AUTHZ}
+        done
+        echo "  ]" >> ${AUTHZ}
+    fi
+
+    echo "}" >> ${AUTHZ}
+}
+
+if [[ "${NATS_JETSTREAM_ENABLE}" == "true" ]]; then
+    cat >> ${CONFIG} <<'EOF'
+
+jetstream {
+  store_dir: /data/jetstream
+}
+EOF
+    echo "[ ! ] JetStream ENABLED"
+else
+    echo "[ ! ] JetStream DISABLED"
+fi
+
+generate_authorization
+echo "[ ! ] GENERATED AUTHORIZATION FILE ::: ${AUTHZ}"
+if [[ -n "${NATS_AUTH_USERS}" ]]; then
+    IFS=';' read -ra ENTRIES <<< "${NATS_AUTH_USERS}"
+    for entry in "${ENTRIES[@]}"; do
+        IFS=':' read -r cn pub sub <<< "${entry}"
+        echo "[ ! ]   User: ${cn} publish=[${pub:-DENY}] subscribe=[${sub:-DENY}]"
+    done
+else
+    echo "[ ! ]   No users configured. All access denied."
+fi

--- a/nats/config/template/nats.conf
+++ b/nats/config/template/nats.conf
@@ -1,0 +1,11 @@
+server_name: ${NATS_CLUSTER_NAME}
+listen: 0.0.0.0:4222
+
+tls {
+  cert_file: /certs/${NATS_TRAEFIK_HOST}.crt
+  key_file: /certs/${NATS_TRAEFIK_HOST}.key
+  ca_file: /certs/root_ca.crt
+  verify_and_map: true
+}
+
+include authorization.conf

--- a/nats/docker-compose.yaml
+++ b/nats/docker-compose.yaml
@@ -1,0 +1,57 @@
+volumes:
+  nats_config:
+  nats_data:
+  certs:
+
+services:
+  config:
+    build:
+      context: config
+    user: "0:0"
+    restart: "no"
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      - NATS_CLUSTER_NAME
+      - NATS_TRAEFIK_HOST
+      - NATS_AUTH_USERS
+      - NATS_JETSTREAM_ENABLE
+    volumes:
+      - nats_config:/etc/nats
+    labels:
+      - "backup-volume.stop-during-backup=true"
+
+  nats:
+    depends_on:
+      config:
+        condition: service_completed_successfully
+    build:
+      context: nats
+      args:
+        NATS_IMAGE: ${NATS_IMAGE}
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    entrypoint: ["/nats-entrypoint.sh"]
+    environment:
+      - NATS_TRAEFIK_HOST
+    ports:
+      - "${NATS_CLIENT_PORT}:4222"
+    volumes:
+      - nats_config:/etc/nats:ro
+      - nats_data:/data
+      - certs:/certs
+    labels: []
+
+  step-cli:
+    build:
+      context: step-cli
+      args:
+        STEP_CLI_IMAGE: ${NATS_STEP_CLI_IMAGE}
+    environment:
+      - NATS_TRAEFIK_HOST
+      - NATS_STEP_CA_URL
+      - NATS_STEP_CA_FINGERPRINT
+      - NATS_STEP_CA_TOKEN
+    volumes:
+      - certs:/home/step/certs

--- a/nats/nats/Dockerfile
+++ b/nats/nats/Dockerfile
@@ -1,0 +1,4 @@
+ARG NATS_IMAGE
+FROM ${NATS_IMAGE}
+COPY --chmod=755 nats-entrypoint.sh /nats-entrypoint.sh
+ENTRYPOINT ["/nats-entrypoint.sh"]

--- a/nats/nats/nats-entrypoint.sh
+++ b/nats/nats/nats-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+timeout=300
+interval=5
+
+if [ -z "${NATS_TRAEFIK_HOST}" ]; then
+    echo "NATS_TRAEFIK_HOST is empty."
+    exit 1
+fi
+
+while [ $timeout -gt 0 ]; do
+    if [ -f /certs/${NATS_TRAEFIK_HOST}.crt ] && \
+       [ -f /certs/${NATS_TRAEFIK_HOST}.key ] && \
+       [ -f /certs/root_ca.crt ]; then
+        echo "## Found full TLS certificate chain."
+        break
+    fi
+    if [ $(( (timeout / interval) % 5 )) -eq 0 ]; then
+        echo "## Waiting for TLS certificate creation before startup ..."
+    fi
+    sleep $interval
+    timeout=$((timeout - interval))
+done
+
+if [ $timeout -le 0 ]; then
+    echo "## Timeout: Not all required files exist after 5 minutes."
+    exit 1
+fi
+
+exec nats-server --config /etc/nats/nats.conf

--- a/nats/step-cli/Dockerfile
+++ b/nats/step-cli/Dockerfile
@@ -1,0 +1,30 @@
+ARG STEP_CLI_IMAGE
+FROM ${STEP_CLI_IMAGE}
+USER root
+
+# Determine the correct architecture and download the appropriate gosu binary
+# https://github.com/tianon/gosu
+RUN apk add --no-cache wget jq gpg gpg-agent && \
+    gpg --batch --no-tty --keyserver hkps://keys.openpgp.org \
+    --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
+    arch=$(apk --print-arch) && \
+    case "$arch" in \
+        x86_64)   dpkg_arch="amd64" ;; \
+        aarch64)  dpkg_arch="arm64" ;; \
+        armv7)    dpkg_arch="armhf" ;; \
+        armv6)    dpkg_arch="armel" ;; \
+        x86)      dpkg_arch="i386" ;; \
+        *)        echo "Unsupported architecture: $arch" && exit 1 ;; \
+    esac && \
+    gosu_url=$(wget -qO- "https://api.github.com/repos/tianon/gosu/releases/latest" | \
+    jq -r --arg arch "gosu-${dpkg_arch}" '.assets[] | select(.name == $arch) | .browser_download_url') && \
+    echo "Downloading: $gosu_url" && \
+    wget -q -O /usr/local/bin/gosu "$gosu_url" || (echo "Failed to download gosu from $gosu_url" && exit 1) && \
+    wget -q -O /usr/local/bin/gosu.asc "${gosu_url}.asc" || (echo "Failed to download signature" && exit 1) && \
+    gpg --batch --no-tty --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
+    chmod +x /usr/local/bin/gosu && \
+    gosu --version
+
+COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY --chmod=755 entrypoint-user.sh /usr/local/bin/entrypoint-user.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/nats/step-cli/entrypoint-user.sh
+++ b/nats/step-cli/entrypoint-user.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+mkdir -p ${HOME}/certs
+
+if [[ -z "${NATS_TRAEFIK_HOST}" ]]; then
+    echo "NATS_TRAEFIK_HOST not set."
+    exit 1
+fi
+
+if [[ -z "${NATS_STEP_CA_URL}" ]]; then
+    echo "NATS_STEP_CA_URL not set."
+    exit 1
+fi
+
+if [[ -z "${NATS_STEP_CA_FINGERPRINT}" ]]; then
+    echo "NATS_STEP_CA_FINGERPRINT not set."
+    exit 1
+fi
+
+
+ROOT_CA="${HOME}/certs/root_ca.crt"
+CERT="${HOME}/certs/${NATS_TRAEFIK_HOST}.crt"
+KEY="${HOME}/certs/${NATS_TRAEFIK_HOST}.key"
+
+if [[ ! -f "${ROOT_CA}" ]]; then
+    step ca root ${ROOT_CA} --ca-url "${NATS_STEP_CA_URL}" \
+         --fingerprint "${NATS_STEP_CA_FINGERPRINT}"
+fi
+
+if [[ ! -f "${KEY}" ]]; then
+    if [[ -z "${NATS_STEP_CA_TOKEN}" ]]; then
+        echo "NATS_STEP_CA_TOKEN not set. You must ask Step-CA to generate a one-time-use token for ${NATS_TRAEFIK_HOST}."
+        exit 1
+    fi
+    echo "Creating certificate using one-time-use token (if this fails you may need a fresh token) ..."
+    step ca certificate "${NATS_TRAEFIK_HOST}" "${CERT}" "${KEY}" --token "${NATS_STEP_CA_TOKEN}"
+fi
+
+if [[ ! -f "${KEY}" ]]; then
+    echo "Certificate creation failed!"
+    exit 1
+fi
+
+echo "Starting Step-CA renewal daemon."
+step ca renew --ca-url "${NATS_STEP_CA_URL}" --daemon "${CERT}" "${KEY}"

--- a/nats/step-cli/entrypoint.sh
+++ b/nats/step-cli/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+TARGET_USER=step
+
+chown -R step:step /home/step/certs
+
+# Drop privileges safely
+if [ "$(id -u)" -eq 0 ]; then
+    echo "Switching to user: $TARGET_USER"
+    exec gosu $TARGET_USER /usr/local/bin/entrypoint-user.sh
+else
+    echo "This container should be run as root and it will drop privileges automatically."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- New `nats/` sub-project: NATS server with Step-CA mTLS client authentication, optional JetStream/KV store, and per-user subject authorization
- Includes config container for cert bootstrapping, `step-cli` sidecar for client cert management, and interactive auth-users menu with read-write/read-only/write-only/prefix permission modes

Closes #621

## Test plan

- [x] `make config` and verify Step-CA token prompt, JetStream toggle, auth-users menu
- [x] `make install` and confirm NATS server starts with mTLS
- [x] Test client connections with Step-CA issued certs
- [x] Test JetStream KV store operations with prefix permissions
- [x] Verify `make reconfigure` skips Step-CA token when already set