### PR TITLE
Add OpenBao secrets manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Install these applications at your preference:
 * [Node-RED](nodered#readme) - a graphical event pipeline editor
 * [Ntfy-sh](ntfy-sh#readme) - a simple HTTP-based pub-sub notification service
 * [Ollama](ollama#readme) - a service API for hosting Large Language Models
+* [OpenBao](openbao#readme) - a secrets management service (Vault)
 * [Open WebUI](open-webui#readme) - a self-hosted AI platform
 * [Pairdrop](pairdrop#readme) - a webapp (PWA) to send files and messages peer to peer
 * [Peertube](peertube#readme) - a decentralized and federated video platform

--- a/openbao/.env-dist
+++ b/openbao/.env-dist
@@ -1,0 +1,65 @@
+# The docker image to use:
+OPENBAO_IMAGE=openbao/openbao:2.1.0
+
+# The domain name for the OpenBao service:
+OPENBAO_TRAEFIK_HOST=bao.example.com
+
+# The name of this instance. If there is only one instance, use 'default'.
+OPENBAO_INSTANCE=
+# You can protect this instance from uninstallation by setting this true:
+## If true, make this instance immune to: `make uninstall`, `make destroy`
+## Still allowed regardless: `make install`, `make stop`, `make start`, `make restart`
+OPENBAO_INSTANCE_PROTECTION=false
+
+# Filter access by IP address source range (CIDR):
+##Disallow all access: 0.0.0.0/32
+##Allow all access: 0.0.0.0/0
+OPENBAO_IP_SOURCERANGE=0.0.0.0/0
+
+# HTTP Basic Authentication:
+# Use `make config` to fill this in properly, or set this to blank to disable.
+OPENBAO_HTTP_AUTH=
+
+# OAUTH2
+# Set to `true` to use OpenID/OAuth2 authentication via the
+# traefik-forward-auth service in d.rymcg.tech.
+# Using OpenID/OAuth2 will require login to access your app,
+# but it will not affect what a successfully logged-in person can do in your
+# app. If your app has built-in authentication and can check the user
+# header that traefik-forward-auth sends, then your app can limit what the
+# logged-in person can do in the app. But if your app can't check the user
+# header, or if your app doesn't have built-in authentication at all, then
+# any person with an account on your Forgejo server can log into your app and
+# have full access.
+OPENBAO_OAUTH2=false
+# In addition to Oauth2 authentication, you can configure basic authorization
+# by entering which authorization group can log into your app. You create
+# groups of email addresses in the `traefik` folder by running `make groups`.
+OPENBAO_OAUTH2_AUTHORIZED_GROUP=
+
+# Mutual TLS (mTLS):
+# HIGHLY RECOMMENDED: Set true to require all clients to present a certificate signed by Step-CA.
+# Without mTLS, the OpenBao API is exposed to unauthenticated network access:
+OPENBAO_MTLS_AUTH=false
+# Enter a comma separated list of client domains allowed to connect via mTLS.
+# Wildcards are allowed and encouraged on a per-app basis:
+OPENBAO_MTLS_AUTHORIZED_CERTS=*.clients.bao.example.com
+
+### OpenBao init config:
+# Number of key shares and threshold for unsealing (Shamir's Secret Sharing).
+# For personal/small-team use, 1/1 is fine. For distributed trust, use e.g. 5/3:
+OPENBAO_KEY_SHARES=1
+OPENBAO_KEY_THRESHOLD=1
+
+### OpenBao config:
+# Storage backend: file or raft
+OPENBAO_STORAGE_BACKEND=file
+# Log level: trace, debug, info, warn, error
+OPENBAO_LOG_LEVEL=info
+# Disable mlock (set true if running without IPC_LOCK capability):
+OPENBAO_DISABLE_MLOCK=true
+# Disable TLS on the listener (Traefik handles TLS termination):
+OPENBAO_TLS_DISABLE=true
+
+# META:
+# PREFIX=OPENBAO

--- a/openbao/.env-dist
+++ b/openbao/.env-dist
@@ -38,8 +38,8 @@ OPENBAO_OAUTH2=false
 OPENBAO_OAUTH2_AUTHORIZED_GROUP=
 
 # Mutual TLS (mTLS):
-# HIGHLY RECOMMENDED: Set true to require all clients to present a certificate signed by Step-CA.
-# Without mTLS, the OpenBao API is exposed to unauthenticated network access:
+# Set true to require all clients to present a certificate signed by Step-CA.
+# Adds defense-in-depth: without a valid client cert, the API is completely unreachable:
 OPENBAO_MTLS_AUTH=false
 # Enter a comma separated list of client domains allowed to connect via mTLS.
 # Wildcards are allowed and encouraged on a per-app basis:

--- a/openbao/Makefile
+++ b/openbao/Makefile
@@ -1,0 +1,268 @@
+ROOT_DIR = ..
+include ${ROOT_DIR}/_scripts/Makefile.projects
+include ${ROOT_DIR}/_scripts/Makefile.instance
+
+## NOTE: Never pass BAO_TOKEN (or other secrets) as part of the command string
+## or in COMMAND= arguments. Use `export BAO_TOKEN` + `exec -e BAO_TOKEN` so
+## the token is passed via the process environment and never visible in ps
+## output, docker logs, or make's command echo.
+
+.PHONY: config-hook
+config-hook:
+#### This interactive configuration wizard creates the .env_{DOCKER_CONTEXT}_{INSTANCE} config file using .env-dist as the template:
+#### reconfigure_ask asks the user a question to set the variable into the .env file, and with a provided default value.
+#### reconfigure sets the value of a variable in the .env file without asking.
+#### reconfigure_htpasswd will configure the HTTP Basic Authentication setting the var name and with a provided default value.
+	@${BIN}/reconfigure_ask ${ENV_FILE} OPENBAO_TRAEFIK_HOST "Enter the OpenBao domain name" bao${INSTANCE_URL_SUFFIX}.${ROOT_DOMAIN}
+	@${BIN}/reconfigure ${ENV_FILE} OPENBAO_INSTANCE=$${instance:-default}
+	@${BIN}/reconfigure_auth ${ENV_FILE} OPENBAO
+	@echo ""
+
+.PHONY: override-hook
+override-hook:
+#### This sets the override template variables for docker-compose.instance.yaml:
+#### The template dynamically renders to docker-compose.override_{DOCKER_CONTEXT}_{INSTANCE}.yaml
+#### These settings are used to automatically generate the service container labels, and traefik config, inside the template.
+#### The variable arguments have three forms: `=` `=:` `=@`
+####   name=VARIABLE_NAME    # sets the template 'name' field to the value of VARIABLE_NAME found in the .env file
+####                         # (this hardcodes the value into docker-compose.override.yaml)
+####   name=:VARIABLE_NAME   # sets the template 'name' field to the literal string 'VARIABLE_NAME'
+####                         # (this hardcodes the string into docker-compose.override.yaml)
+####   name=@VARIABLE_NAME   # sets the template 'name' field to the literal string '${VARIABLE_NAME}'
+####                         # (used for regular docker-compose expansion of env vars by name.)
+	@${BIN}/docker_compose_override ${ENV_FILE} project=:openbao instance=@OPENBAO_INSTANCE traefik_host=@OPENBAO_TRAEFIK_HOST http_auth=OPENBAO_HTTP_AUTH http_auth_var=@OPENBAO_HTTP_AUTH ip_sourcerange=@OPENBAO_IP_SOURCERANGE oauth2=OPENBAO_OAUTH2 authorized_group=OPENBAO_OAUTH2_AUTHORIZED_GROUP enable_mtls_auth=OPENBAO_MTLS_AUTH mtls_authorized_certs=OPENBAO_MTLS_AUTHORIZED_CERTS
+
+.PHONY: shell # Enter container shell
+shell:
+	@make --no-print-directory docker-compose-shell SERVICE=openbao
+
+.PHONY: init # Initialize OpenBao (shows unseal keys and root token)
+init:
+	@KEY_SHARES=$$(${BIN}/dotenv -f ${ENV_FILE} get OPENBAO_KEY_SHARES); \
+	KEY_THRESHOLD=$$(${BIN}/dotenv -f ${ENV_FILE} get OPENBAO_KEY_THRESHOLD); \
+	make --no-print-directory docker-compose-shell SERVICE=openbao COMMAND="bao operator init -key-shares=$${KEY_SHARES:-1} -key-threshold=$${KEY_THRESHOLD:-1}"
+
+.PHONY: unseal # Unseal OpenBao (interactive - enter unseal keys)
+unseal:
+	@make --no-print-directory docker-compose-shell SERVICE=openbao COMMAND="bao operator unseal"
+
+.PHONY: seal # Seal OpenBao
+seal:
+	@echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -T openbao /bin/sh -c 'echo; bao operator seal; echo; echo'"
+
+.PHONY: seal-status # Show OpenBao seal status
+seal-status:
+	@make --no-print-directory docker-compose-shell SERVICE=openbao COMMAND="bao status"
+
+.PHONY: enable-ssh-engine # Enable SSH secrets engine at ssh-client-signer
+enable-ssh-engine:
+	@echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -T openbao /bin/sh -c 'echo; bao secrets enable -path=ssh-client-signer ssh; echo; echo'"
+
+.PHONY: configure-ssh-ca # Generate SSH CA signing key
+configure-ssh-ca:
+	@echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -T openbao /bin/sh -c 'echo; bao write ssh-client-signer/config/ca generate_signing_key=true; echo; echo'"
+
+.PHONY: get-ssh-ca-public-key # Output the SSH CA public key (for server TrustedUserCAKeys)
+get-ssh-ca-public-key:
+	@TRAEFIK_HOST=$$(${BIN}/dotenv -f ${ENV_FILE} get OPENBAO_TRAEFIK_HOST); \
+	echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	export BAO_LABEL="## $${TRAEFIK_HOST} SSH CA Public Key"; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -e BAO_LABEL -T openbao /bin/sh -c 'echo; printenv BAO_LABEL; bao read -field=public_key ssh-client-signer/config/ca; echo; echo'"
+
+.PHONY: create-ssh-role # Create SSH signing role (woodpecker-short-lived, 2m TTL, ed25519)
+create-ssh-role:
+	@echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	cat create-ssh-role.sh | make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -i -e BAO_TOKEN -T openbao /bin/sh"
+
+.PHONY: read-ssh-role # Read the SSH signing role configuration
+read-ssh-role:
+	@TRAEFIK_HOST=$$(${BIN}/dotenv -f ${ENV_FILE} get OPENBAO_TRAEFIK_HOST); \
+	echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	export BAO_LABEL="## $${TRAEFIK_HOST} SSH Role: woodpecker-short-lived"; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -e BAO_LABEL -T openbao /bin/sh -c 'echo; printenv BAO_LABEL; bao read ssh-client-signer/roles/woodpecker-short-lived; echo; echo'"
+
+.PHONY: enable-kv # Enable KV v2 secrets engine
+enable-kv:
+	@echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -T openbao /bin/sh -c 'echo; bao secrets enable -version=2 -path=secret kv; echo; echo'"
+
+.PHONY: put-age-key # Store an AGE secret key (usage: make put-age-key path=sops/mykey)
+put-age-key:
+	@if [ -z "$${path}" ]; then echo "ERROR: path is required (e.g., make put-age-key path=sops/d2-admin/myserver-production)" >&2; exit 1; fi; \
+	echo "Storing AGE key at: secret/$${path}"; \
+	echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	echo "Enter the AGE secret key (AGE-SECRET-KEY-...):"; \
+	read -rs BAO_AGE_KEY; export BAO_AGE_KEY; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -e BAO_AGE_KEY -T openbao /bin/sh -c 'echo; bao kv put secret/$${path} key=$${BAO_AGE_KEY}; echo; echo'"
+
+.PHONY: get-age-key # Read a stored AGE key (usage: make get-age-key path=sops/mykey)
+get-age-key:
+	@if [ -z "$${path}" ]; then echo "ERROR: path is required (e.g., make get-age-key path=sops/d2-admin/myserver-production)" >&2; exit 1; fi; \
+	TRAEFIK_HOST=$$(${BIN}/dotenv -f ${ENV_FILE} get OPENBAO_TRAEFIK_HOST); \
+	echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	export BAO_LABEL="## $${TRAEFIK_HOST} AGE Key: $${path}"; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -e BAO_LABEL -T openbao /bin/sh -c 'echo; printenv BAO_LABEL; bao kv get secret/$${path}; echo; echo'"
+
+.PHONY: list-age-keys # List all stored AGE keys under sops/
+list-age-keys:
+	@TRAEFIK_HOST=$$(${BIN}/dotenv -f ${ENV_FILE} get OPENBAO_TRAEFIK_HOST); \
+	echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	export BAO_LABEL="## $${TRAEFIK_HOST} AGE Keys"; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -e BAO_LABEL -T openbao /bin/sh -c 'echo; printenv BAO_LABEL; bao kv list secret/sops; echo; echo'"
+
+.PHONY: delete-age-key # Delete a stored AGE key (usage: make delete-age-key path=sops/mykey)
+delete-age-key:
+	@if [ -z "$${path}" ]; then echo "ERROR: path is required (e.g., make delete-age-key path=sops/d2-admin/myserver-production)" >&2; exit 1; fi; \
+	echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -T openbao /bin/sh -c 'echo; bao kv metadata delete secret/$${path}; echo; echo'"
+
+.PHONY: enable-approle # Enable AppRole auth method
+enable-approle:
+	@echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -T openbao /bin/sh -c 'echo; bao auth enable approle; echo; echo'"
+
+.PHONY: disable-approle # Disable AppRole auth method
+disable-approle:
+	@echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -T openbao /bin/sh -c 'echo; bao auth disable approle; echo; echo'"
+
+.PHONY: list-approles # List all AppRoles
+list-approles:
+	@TRAEFIK_HOST=$$(${BIN}/dotenv -f ${ENV_FILE} get OPENBAO_TRAEFIK_HOST); \
+	echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	export BAO_LABEL="## $${TRAEFIK_HOST} AppRoles"; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -e BAO_LABEL -T openbao /bin/sh -c 'echo; printenv BAO_LABEL; bao list auth/approle/role; echo; echo'"
+
+.PHONY: delete-approles # Delete AppRoles (interactive selection)
+delete-approles:
+	@echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	ROLES=$$(make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -T openbao bao list -format=json auth/approle/role" 2>/dev/null | jq -r '.[]'); \
+	if [ -z "$${ROLES}" ]; then echo ""; echo "No AppRoles found."; echo; echo; exit 0; fi; \
+	readarray -t ROLE_ARRAY <<< "$${ROLES}"; \
+	readarray -t SELECTED < <(${BIN}/script-wizard select "Select AppRoles to delete" "$${ROLE_ARRAY[@]}"); \
+	if [ $${#SELECTED[@]} -eq 0 ]; then echo ""; echo "No AppRoles selected."; echo; echo; exit 0; fi; \
+	echo; \
+	for role in "$${SELECTED[@]}"; do \
+		echo "Deleting AppRole: $${role}"; \
+		make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -T openbao bao delete auth/approle/role/$${role}" 2>/dev/null; \
+	done; \
+	echo; echo
+
+.PHONY: list-policies # List all policies
+list-policies:
+	@TRAEFIK_HOST=$$(${BIN}/dotenv -f ${ENV_FILE} get OPENBAO_TRAEFIK_HOST); \
+	echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	export BAO_LABEL="## $${TRAEFIK_HOST} Policies"; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -e BAO_LABEL -T openbao /bin/sh -c 'echo; printenv BAO_LABEL; bao policy list; echo; echo'"
+
+.PHONY: delete-policies # Delete policies (interactive selection)
+delete-policies:
+	@echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	POLICIES=$$(make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -T openbao bao policy list -format=json" 2>/dev/null | jq -r '.[]' | grep -vxE 'default|root'); \
+	if [ -z "$${POLICIES}" ]; then echo ""; echo "No deletable policies found."; echo; echo; exit 0; fi; \
+	readarray -t POLICY_ARRAY <<< "$${POLICIES}"; \
+	readarray -t SELECTED < <(${BIN}/script-wizard select "Select policies to delete" "$${POLICY_ARRAY[@]}"); \
+	if [ $${#SELECTED[@]} -eq 0 ]; then echo ""; echo "No policies selected."; echo; echo; exit 0; fi; \
+	echo; \
+	for policy in "$${SELECTED[@]}"; do \
+		echo "Deleting policy: $${policy}"; \
+		make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -T openbao bao policy delete $${policy}" 2>/dev/null; \
+	done; \
+	echo; echo
+
+.PHONY: setup-deploy-repo # Create policy + AppRole and show Woodpecker secrets (usage: make setup-deploy-repo repo=d2-admin)
+setup-deploy-repo:
+	@if [ -z "$${repo}" ]; then echo "ERROR: repo is required (e.g., make setup-deploy-repo repo=d2-admin)" >&2; exit 1; fi; \
+	TRAEFIK_HOST=$$(${BIN}/dotenv -f ${ENV_FILE} get OPENBAO_TRAEFIK_HOST); \
+	echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	echo; \
+	echo "Creating policy: $${repo}-deploy ..."; \
+	POLICY=$$(printf 'path "secret/data/sops/%s/*" {\n  capabilities = ["read"]\n}\n\npath "ssh-client-signer/sign/woodpecker-short-lived" {\n  capabilities = ["create", "update"]\n}' "$${repo}" | base64 -w0); \
+	make --no-print-directory docker-compose-lifecycle-cmd QUIET=true EXTRA_ARGS="exec -e BAO_TOKEN -T openbao /bin/sh -c 'echo $${POLICY} | base64 -d | bao policy write $${repo}-deploy -'"; \
+	echo "Creating AppRole: $${repo}-deploy ..."; \
+	ROLE=$$(printf '{"token_policies":"%s-deploy","token_ttl":"20m","token_max_ttl":"30m","secret_id_ttl":"0"}' "$${repo}" | base64 -w0); \
+	make --no-print-directory docker-compose-lifecycle-cmd QUIET=true EXTRA_ARGS="exec -e BAO_TOKEN -T openbao /bin/sh -c 'echo $${ROLE} | base64 -d | bao write auth/approle/role/$${repo}-deploy -'"; \
+	echo "Retrieving credentials ..."; \
+	ROLE_ID=$$(make --no-print-directory docker-compose-lifecycle-cmd QUIET=true EXTRA_ARGS="exec -e BAO_TOKEN -T openbao bao read -field=role_id auth/approle/role/$${repo}-deploy/role-id"); \
+	SECRET_ID=$$(make --no-print-directory docker-compose-lifecycle-cmd QUIET=true EXTRA_ARGS="exec -e BAO_TOKEN -T openbao bao write -field=secret_id -f auth/approle/role/$${repo}-deploy/secret-id"); \
+	echo; \
+	echo "## $${TRAEFIK_HOST} Woodpecker Secrets: $${repo}"; \
+	echo "## Add these as secrets in your Woodpecker CI repository:"; \
+	echo; \
+	echo "bao_addr          = https://$${TRAEFIK_HOST}"; \
+	echo "bao_role_id       = $${ROLE_ID}"; \
+	echo "bao_secret_id     = $${SECRET_ID}"; \
+	echo "bao_age_key_path  = sops/$${repo}/<context>"; \
+	echo; \
+	echo "## Optional (if using a private CA like Step-CA):"; \
+	echo "bao_cacert        = <CA root certificate PEM or base64>"; \
+	echo; \
+	echo "## Optional (if mTLS is enabled on OpenBao):"; \
+	echo "bao_client_cert   = <mTLS client certificate PEM or base64>"; \
+	echo "bao_client_key    = <mTLS client key PEM or base64>"; \
+	echo; echo
+
+.PHONY: create-policy # Create a deploy repo policy (usage: make create-policy repo=d2-admin)
+create-policy:
+	@if [ -z "$${repo}" ]; then echo "ERROR: repo is required (e.g., make create-policy repo=d2-admin)" >&2; exit 1; fi; \
+	echo "Creating policy: $${repo}-deploy (read sops/$${repo}/*, sign SSH keys)"; \
+	echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	POLICY=$$(printf 'path "secret/data/sops/%s/*" {\n  capabilities = ["read"]\n}\n\npath "ssh-client-signer/sign/woodpecker-short-lived" {\n  capabilities = ["create", "update"]\n}' "$${repo}" | base64 -w0); \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -T openbao /bin/sh -c 'echo; echo $${POLICY} | base64 -d | bao policy write $${repo}-deploy -; echo; echo'"
+
+.PHONY: create-approle # Create an AppRole for a deploy repo (usage: make create-approle repo=d2-admin)
+create-approle:
+	@if [ -z "$${repo}" ]; then echo "ERROR: repo is required (e.g., make create-approle repo=d2-admin)" >&2; exit 1; fi; \
+	echo "Creating AppRole: $${repo}-deploy (policy: $${repo}-deploy, 20m TTL)"; \
+	echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	ROLE=$$(printf '{"token_policies":"%s-deploy","token_ttl":"20m","token_max_ttl":"30m","secret_id_ttl":"0"}' "$${repo}" | base64 -w0); \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -T openbao /bin/sh -c 'echo; echo $${ROLE} | base64 -d | bao write auth/approle/role/$${repo}-deploy -; echo; echo'"
+
+.PHONY: get-role-id # Get an AppRole role ID (usage: make get-role-id repo=d2-admin)
+get-role-id:
+	@if [ -z "$${repo}" ]; then echo "ERROR: repo is required (e.g., make get-role-id repo=d2-admin)" >&2; exit 1; fi; \
+	TRAEFIK_HOST=$$(${BIN}/dotenv -f ${ENV_FILE} get OPENBAO_TRAEFIK_HOST); \
+	echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	export BAO_LABEL="## $${TRAEFIK_HOST} Role ID: $${repo}"; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -e BAO_LABEL -T openbao /bin/sh -c 'echo; printenv BAO_LABEL; bao read -field=role_id auth/approle/role/$${repo}-deploy/role-id; echo; echo'"
+
+.PHONY: generate-secret-id # Generate an AppRole secret ID (usage: make generate-secret-id repo=d2-admin)
+generate-secret-id:
+	@if [ -z "$${repo}" ]; then echo "ERROR: repo is required (e.g., make generate-secret-id repo=d2-admin)" >&2; exit 1; fi; \
+	TRAEFIK_HOST=$$(${BIN}/dotenv -f ${ENV_FILE} get OPENBAO_TRAEFIK_HOST); \
+	echo "Enter the root token:"; \
+	read -rs BAO_TOKEN; export BAO_TOKEN; \
+	export BAO_LABEL="## $${TRAEFIK_HOST} Secret Key: $${repo}"; \
+	make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="exec -e BAO_TOKEN -e BAO_LABEL -T openbao /bin/sh -c 'echo; printenv BAO_LABEL; bao write -field=secret_id -f auth/approle/role/$${repo}-deploy/secret-id; echo; echo'"
+
+.PHONY: install-hook
+install-hook:
+	@echo
+
+.PHONY: install-hook-pre
+install-hook-pre:
+	@echo

--- a/openbao/README.md
+++ b/openbao/README.md
@@ -1,0 +1,184 @@
+# OpenBao
+
+[OpenBao](https://openbao.org/) is an open-source secrets management
+platform (a fork of HashiCorp Vault, API-compatible with the v1 API).
+It provides centralized secrets storage, dynamic credentials, and
+identity-based access.
+
+In this d.rymcg.tech deployment, OpenBao serves as:
+
+- **SSH Certificate Authority** — issues short-lived SSH certificates
+  for CI/CD pipelines (no static SSH keys).
+- **AGE key store** — holds the AGE private key used to decrypt
+  SOPS-encrypted configuration files.
+- **AppRole auth** — machine-friendly authentication for Woodpecker CI
+  agents.
+
+## Security
+
+Enabling mTLS (`OPENBAO_MTLS_AUTH=true`) is **HIGHLY RECOMMENDED**.
+Without mTLS, the OpenBao API is exposed to unauthenticated network
+access. With mTLS enabled, all clients must present a valid
+certificate signed by your Step-CA before Traefik will proxy the
+request to OpenBao. See [Step-CA](../step-ca#readme) for setting up
+your certificate authority.
+
+## Setup
+
+```bash
+## Configure the OpenBao env:
+d.rymcg.tech make openbao config
+
+## Install OpenBao:
+d.rymcg.tech make openbao install
+```
+
+## Initialization
+
+After first install, OpenBao must be initialized and unsealed:
+
+```bash
+## Initialize (save the unseal keys and root token securely!):
+d.rymcg.tech make openbao init
+
+## Unseal (must provide threshold number of unseal keys):
+d.rymcg.tech make openbao unseal
+
+## Check seal status:
+d.rymcg.tech make openbao seal-status
+```
+
+**Important:** Save both values in a secure offline password manager
+(e.g., KeePassXC):
+
+- **Unseal key** — required every time OpenBao restarts (it always
+  starts sealed). Without it, all stored secrets are permanently
+  inaccessible.
+- **Root token** — the initial admin credential for configuring
+  OpenBao (enabling engines, creating policies, AppRoles). Can be
+  revoked after setup, but is needed for all initial configuration.
+
+## SSH Certificate Authority
+
+Set up OpenBao as an SSH CA so CI/CD pipelines can obtain short-lived
+SSH certificates:
+
+```bash
+## Enable the SSH secrets engine:
+d.rymcg.tech make openbao enable-ssh-engine
+
+## Generate the CA signing key:
+d.rymcg.tech make openbao configure-ssh-ca
+
+## Get the CA public key (add this to your servers):
+d.rymcg.tech make openbao get-ssh-ca-public-key
+
+## Create a signing role for CI/CD (15-minute TTL):
+d.rymcg.tech make openbao create-ssh-role
+
+## Verify the role configuration:
+d.rymcg.tech make openbao read-ssh-role
+```
+
+### Server sshd configuration
+
+On each target server, add the CA public key to
+`/etc/ssh/trusted_user_ca_keys`:
+
+```bash
+## On the target server:
+echo "<CA_PUBLIC_KEY>" > /etc/ssh/trusted_user_ca_keys
+
+## Add to /etc/ssh/sshd_config:
+echo "TrustedUserCAKeys /etc/ssh/trusted_user_ca_keys" >> /etc/ssh/sshd_config
+
+## Restart sshd:
+systemctl restart sshd
+```
+
+## AGE Key for SOPS
+
+An AGE key is used to encrypt and decrypt SOPS configuration files.
+If you don't already have one, generate it:
+
+```bash
+age-keygen
+```
+
+This outputs two lines:
+- A comment with the **public key** (`age1...`) — used in your
+  `.sops.yaml` to specify who can encrypt.
+- The **secret key** (`AGE-SECRET-KEY-...`) — needed for decryption.
+
+Save both in your offline password manager. Then enable the KV secrets
+engine and store the secret key in OpenBao:
+
+```bash
+## Enable the KV secrets engine (if not already enabled):
+d.rymcg.tech make openbao enable-kv
+
+## Store AGE secret keys (path is required):
+d.rymcg.tech make openbao put-age-key path=sops/d2-admin/myserver-production
+d.rymcg.tech make openbao put-age-key path=sops/d2-admin/myserver-staging
+
+## List all stored keys:
+d.rymcg.tech make openbao list-age-keys
+
+## Verify a specific key:
+d.rymcg.tech make openbao get-age-key path=sops/d2-admin/myserver-production
+
+## Delete a key:
+d.rymcg.tech make openbao delete-age-key path=sops/d2-admin/myserver-staging
+```
+
+The path structure is `sops/<deployment-repo>/<context>`, where
+`<deployment-repo>` is the name of your d.rymcg.tech deployment repo
+(e.g., `d2-admin`) and `<context>` identifies the Docker context
+(e.g., `myserver-production`). This allows each deployment repo's
+AppRole policy to grant access only to its own keys
+(`sops/d2-admin/*`).
+
+In your Woodpecker pipeline, set `BAO_AGE_KEY_PATH` to the path
+used above (e.g., `sops/d2-admin/myserver-production`).
+
+The d.rymcg.tech container entrypoint will retrieve this key
+automatically when `BAO_ADDR` is set.
+
+## AppRole Authentication and Woodpecker CI Secrets
+
+Each deployment repo gets its own policy, AppRole, and credentials.
+The policy grants read access to AGE keys under
+`secret/data/sops/<repo>/*` and permission to sign SSH public keys.
+
+```bash
+## Enable AppRole auth method (once):
+d.rymcg.tech make openbao enable-approle
+
+## Set up a deployment repo (creates policy + AppRole, shows Woodpecker secrets):
+d.rymcg.tech make openbao setup-deploy-repo repo=d2-admin
+```
+
+This creates the policy and AppRole, then outputs all the secrets you
+need to add to your Woodpecker CI repository:
+
+| Secret | Description |
+|--------|-------------|
+| `bao_addr` | OpenBao server URL (e.g., `https://bao.example.com`) |
+| `bao_role_id` | AppRole role ID |
+| `bao_secret_id` | AppRole secret ID |
+| `bao_age_key_path` | KV path to AGE key (e.g., `sops/d2-admin/myserver-production`) |
+| `bao_cacert` | CA root certificate, PEM or base64 (only if using a private CA like Step-CA) |
+| `bao_client_cert` | mTLS client certificate, PEM or base64 (only if mTLS is enabled) |
+| `bao_client_key` | mTLS client key, PEM or base64 (only if mTLS is enabled) |
+
+The individual steps are also available as separate commands:
+
+```bash
+d.rymcg.tech make openbao create-policy repo=d2-admin
+d.rymcg.tech make openbao create-approle repo=d2-admin
+d.rymcg.tech make openbao get-role-id repo=d2-admin
+d.rymcg.tech make openbao generate-secret-id repo=d2-admin
+```
+
+See the [Woodpecker templates](../woodpecker/templates/) for example
+pipeline configurations.

--- a/openbao/README.md
+++ b/openbao/README.md
@@ -16,12 +16,17 @@ In this d.rymcg.tech deployment, OpenBao serves as:
 
 ## Security
 
-Enabling mTLS (`OPENBAO_MTLS_AUTH=true`) is **HIGHLY RECOMMENDED**.
-Without mTLS, the OpenBao API is exposed to unauthenticated network
-access. With mTLS enabled, all clients must present a valid
-certificate signed by your Step-CA before Traefik will proxy the
-request to OpenBao. See [Step-CA](../step-ca#readme) for setting up
-your certificate authority.
+OpenBao requires authentication (root token, AppRole, etc.) for all
+API operations — secrets are never accessible without valid
+credentials. Additionally, data at rest is encrypted and OpenBao
+starts sealed after every restart.
+
+Enabling mTLS (`OPENBAO_MTLS_AUTH=true`) adds defense-in-depth at the
+network layer: without a valid client certificate, clients cannot
+reach the API at all, making the server opaque to unauthorized
+parties (no endpoint discovery, no health checks, nothing). See
+[Step-CA](../step-ca#readme) for setting up your certificate
+authority.
 
 ## Setup
 

--- a/openbao/README.md
+++ b/openbao/README.md
@@ -18,8 +18,11 @@ In this d.rymcg.tech deployment, OpenBao serves as:
 
 OpenBao requires authentication (root token, AppRole, etc.) for all
 API operations — secrets are never accessible without valid
-credentials. Additionally, data at rest is encrypted and OpenBao
-starts sealed after every restart.
+credentials. Data at rest is encrypted and OpenBao starts sealed
+after every restart. TLS is disabled on the container itself
+(`OPENBAO_TLS_DISABLE=true`); Traefik handles TLS termination, and
+traffic between Traefik and OpenBao stays on the internal Docker
+network.
 
 Enabling mTLS (`OPENBAO_MTLS_AUTH=true`) adds defense-in-depth at the
 network layer: without a valid client certificate, clients cannot

--- a/openbao/create-ssh-role.sh
+++ b/openbao/create-ssh-role.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+## Creates the SSH signing role for short-lived certificates.
+## This script runs inside the openbao container.
+set -e
+
+cat <<'EOF' | bao write ssh-client-signer/roles/woodpecker-short-lived -
+{
+  "allow_user_certificates": true,
+  "allowed_users": "*",
+  "default_extensions": {
+    "permit-pty": "",
+    "permit-port-forwarding": ""
+  },
+  "key_type": "ca",
+  "default_user": "root",
+  "ttl": "2m",
+  "max_ttl": "5m",
+  "algorithm_signer": "default"
+}
+EOF

--- a/openbao/docker-compose.instance.yaml
+++ b/openbao/docker-compose.instance.yaml
@@ -1,0 +1,64 @@
+#! This is a ytt template file for docker-compose.override.yaml
+#! References:
+#!   https://carvel.dev/ytt
+#!   https://docs.docker.com/compose/extends/#adding-and-overriding-configuration
+#!   https://github.com/enigmacurry/d.rymcg.tech#overriding-docker-composeyaml-per-instance
+
+#! ### Standard project vars:
+#@ load("@ytt:data", "data")
+#@ project = data.values.project
+#@ instance = data.values.instance
+#@ context = data.values.context
+#@ traefik_host = data.values.traefik_host
+#@ ip_sourcerange = data.values.ip_sourcerange
+#@ enable_http_auth = len(data.values.http_auth.strip()) > 0
+#@ http_auth = data.values.http_auth
+#@ enable_oauth2 = data.values.oauth2 == "true"
+#@ authorized_group = data.values.authorized_group
+#@ enable_mtls_auth = data.values.enable_mtls_auth == "true"
+#@ mtls_authorized_certs = data.values.mtls_authorized_certs
+#@ enabled_middlewares = []
+
+#@yaml/text-templated-strings
+services:
+  openbao:
+    #@ service = "openbao"
+    labels:
+      - "backup-volume.stop-during-backup=true"
+      #! Services must opt-in to be proxied by Traefik:
+      - "traefik.enable=true"
+
+      #! 'router' is the fully qualified key in traefik for this router/service: project + instance + service
+      #@ router = "{}-{}-{}".format(project,instance,service)
+
+      #! The host matching router rule:
+      - "traefik.http.routers.(@= router @).rule=Host(`(@= traefik_host @)`)"
+      - "traefik.http.routers.(@= router @).entrypoints=websecure"
+
+      #@ enabled_middlewares.append("{}-ipallowlist".format(router))
+      - "traefik.http.middlewares.(@= router @)-ipallowlist.ipallowlist.sourcerange=(@= ip_sourcerange @)"
+      #@ if enable_http_auth:
+      #@ enabled_middlewares.append("{}-basicauth".format(router))
+      - "traefik.http.middlewares.(@= router @)-basicauth.basicauth.users=(@= http_auth @)"
+      - "traefik.http.middlewares.(@= router @)-basicauth.basicauth.headerField=X-Forwarded-User"
+      #@ end
+
+      #@ if enable_oauth2:
+      #@ enabled_middlewares.append("traefik-forward-auth@docker")
+      #@ enabled_middlewares.append("header-authorization-group-{}@file".format(authorized_group))
+      #@ end
+
+      #@ if enable_mtls_auth:
+      - "traefik.http.routers.(@= router @).tls.options=step_ca_mTLS@file"
+        #@ if len(mtls_authorized_certs):
+      - "traefik.http.middlewares.mtlsauth-(@= router @).plugin.certauthz.domains=(@= mtls_authorized_certs @)"
+        #@ enabled_middlewares.append("mtlsauth-{}".format(router))
+        #@ end
+        #@ enabled_middlewares.append("mtls-header@file")
+      #@ end
+
+      #! Override the default port that the app binds to:
+      - "traefik.http.services.(@= router @).loadbalancer.server.port=8200"
+
+      #! Apply all middlewares (do this at the end!)
+      - "traefik.http.routers.(@= router @).middlewares=(@= ','.join(enabled_middlewares) @)"

--- a/openbao/docker-compose.yaml
+++ b/openbao/docker-compose.yaml
@@ -1,0 +1,23 @@
+volumes:
+  data:
+  config:
+  logs:
+
+services:
+  openbao:
+    image: ${OPENBAO_IMAGE}
+    cap_add:
+      - IPC_LOCK
+    restart: unless-stopped
+    environment:
+      - BAO_ADDR=http://127.0.0.1:8200
+      - BAO_LOCAL_CONFIG={"storage":{"${OPENBAO_STORAGE_BACKEND}":{"path":"/openbao/file"}},"listener":{"tcp":{"address":"0.0.0.0:8200","tls_disable":"${OPENBAO_TLS_DISABLE}"}},"disable_mlock":${OPENBAO_DISABLE_MLOCK},"log_level":"${OPENBAO_LOG_LEVEL}","api_addr":"https://${OPENBAO_TRAEFIK_HOST}"}
+    volumes:
+      - data:/openbao/file
+      - config:/openbao/config
+      - logs:/openbao/logs
+    command: server
+    # All labels are defined in the template: docker-compose.instance.yaml
+    # The labels will merge together here from the template output:
+    #   docker-compose.override_{DOCKER_CONTEXT}_{INSTANCE}.yaml
+    labels: []


### PR DESCRIPTION
## Summary
- Adds OpenBao (open-source Vault fork) as a standalone deployable app
- Includes SSH Certificate Authority, AGE key store, AppRole auth, and KV secrets engine
- Supports mTLS, OAuth2, HTTP basic auth, and IP source range filtering via Traefik

Closes #626