### PR TITLE
Rename http_auth_var to http_auth in instance templates

### DIFF
--- a/_attic/drawio/docker-compose.instance.yaml
+++ b/_attic/drawio/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/_attic/filestash/docker-compose.instance.yaml
+++ b/_attic/filestash/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/_attic/larynx/docker-compose.instance.yaml
+++ b/_attic/larynx/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/_attic/ttrss/docker-compose.instance.yaml
+++ b/_attic/ttrss/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/actual/docker-compose.instance.yaml
+++ b/actual/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/archivebox/docker-compose.instance.yaml
+++ b/archivebox/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/aria2/docker-compose.instance.yaml
+++ b/aria2/docker-compose.instance.yaml
@@ -16,7 +16,7 @@
 
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/backrest/docker-compose.instance.yaml
+++ b/backrest/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/baikal/docker-compose.instance.yaml
+++ b/baikal/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/calcpad/docker-compose.instance.yaml
+++ b/calcpad/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/calibre/docker-compose.instance.yaml
+++ b/calibre/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/comfyui/docker-compose.instance.yaml
+++ b/comfyui/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/commentario/docker-compose.instance.yaml
+++ b/commentario/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/copyparty/docker-compose.instance.yaml
+++ b/copyparty/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/datetime/docker-compose.instance.yaml
+++ b/datetime/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/excalidraw/docker-compose.instance.yaml
+++ b/excalidraw/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/filebrowser/docker-compose.instance.yaml
+++ b/filebrowser/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/firefox/docker-compose.instance.yaml
+++ b/firefox/docker-compose.instance.yaml
@@ -14,7 +14,7 @@
 
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/freshrss/docker-compose.instance.yaml
+++ b/freshrss/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/glances/docker-compose.instance.yaml
+++ b/glances/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/gradio/docker-compose.instance.yaml
+++ b/gradio/docker-compose.instance.yaml
@@ -13,7 +13,7 @@
 #@ traefik_entrypoint = data.values.traefik_entrypoint
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/grocy/docker-compose.instance.yaml
+++ b/grocy/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/homepage/docker-compose.instance.yaml
+++ b/homepage/docker-compose.instance.yaml
@@ -13,7 +13,7 @@
 #@ webhook_host = data.values.webhook_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/immich/docker-compose.instance.yaml
+++ b/immich/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/invidious/docker-compose.instance.yaml
+++ b/invidious/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/invokeai/docker-compose.instance.yaml
+++ b/invokeai/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/it-tools/docker-compose.instance.yaml
+++ b/it-tools/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/jupyterlab/docker-compose.instance.yaml
+++ b/jupyterlab/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/kokoro/docker-compose.instance.yaml
+++ b/kokoro/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/lemmy/docker-compose.instance.yaml
+++ b/lemmy/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/llama-cpp/docker-compose.instance.yaml
+++ b/llama-cpp/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/maubot/docker-compose.instance.yaml
+++ b/maubot/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/minio/docker-compose.instance.yaml
+++ b/minio/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/nextcloud/docker-compose.instance.yaml
+++ b/nextcloud/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/nginx/docker-compose.instance.yaml
+++ b/nginx/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/nodered/docker-compose.instance.yaml
+++ b/nodered/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/ollama/docker-compose.instance.yaml
+++ b/ollama/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/open-webui/docker-compose.instance.yaml
+++ b/open-webui/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/pairdrop/docker-compose.instance.yaml
+++ b/pairdrop/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/peertube/docker-compose.instance.yaml
+++ b/peertube/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/photoprism/docker-compose.instance.yaml
+++ b/photoprism/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/piwigo/docker-compose.instance.yaml
+++ b/piwigo/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/privatebin/docker-compose.instance.yaml
+++ b/privatebin/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/prometheus/docker-compose.instance.yaml
+++ b/prometheus/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/qbittorrent/docker-compose.instance.yaml
+++ b/qbittorrent/docker-compose.instance.yaml
@@ -14,7 +14,7 @@
 
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/redbean/docker-compose.instance.yaml
+++ b/redbean/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/redmine/docker-compose.instance.yaml
+++ b/redmine/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/registry/docker-compose.instance.yaml
+++ b/registry/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"
 #@ mtls_authorized_certs = data.values.mtls_authorized_certs
 #@ enabled_middlewares = []
@@ -21,7 +21,7 @@
 #@ s3_storage = data.values.storage_backend == "s3"
 #@ enable_public = data.values.public == "true"
 #@ enable_pull_http_auth = len(data.values.pull_http_auth.strip()) > 0
-#@ pull_http_auth = data.values.pull_http_auth_var
+#@ pull_http_auth = data.values.pull_http_auth
 #@ enable_pull_mtls_auth = data.values.pull_mtls_auth == "true"
 #@ pull_mtls_authorized_certs = data.values.pull_mtls_authorized_certs
 #@ enable_pull_auth = enable_pull_http_auth or enable_pull_mtls_auth

--- a/s3-proxy/docker-compose.instance.yaml
+++ b/s3-proxy/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/searxng/docker-compose.instance.yaml
+++ b/searxng/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/shaarli/docker-compose.instance.yaml
+++ b/shaarli/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/smokeping/docker-compose.instance.yaml
+++ b/smokeping/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/speedtest-tracker/docker-compose.instance.yaml
+++ b/speedtest-tracker/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/syncthing/docker-compose.instance.yaml
+++ b/syncthing/docker-compose.instance.yaml
@@ -14,7 +14,7 @@
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ admin_ip_sourcerange = data.values.admin_ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/sysbox-systemd/docker-compose.instance.yaml
+++ b/sysbox-systemd/docker-compose.instance.yaml
@@ -13,7 +13,7 @@
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ ports = [port for port in data.values.ports.split(" ") if port != ""]
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enabled_middlewares = []
 
 #@yaml/text-templated-strings

--- a/tesseract/docker-compose.instance.yaml
+++ b/tesseract/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/thelounge/docker-compose.instance.yaml
+++ b/thelounge/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/thirteenft/docker-compose.instance.yaml
+++ b/thirteenft/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/thttpd/docker-compose.instance.yaml
+++ b/thttpd/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/trilium/docker-compose.instance.yaml
+++ b/trilium/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/uptime-kuma/docker-compose.instance.yaml
+++ b/uptime-kuma/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/vaultwarden/docker-compose.instance.yaml
+++ b/vaultwarden/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/vllm/docker-compose.instance.yaml
+++ b/vllm/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/websocketd/docker-compose.instance.yaml
+++ b/websocketd/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/webtop/docker-compose.instance.yaml
+++ b/webtop/docker-compose.instance.yaml
@@ -14,7 +14,7 @@
 
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/whoami/docker-compose.instance.yaml
+++ b/whoami/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/wordpress/docker-compose.instance.yaml
+++ b/wordpress/docker-compose.instance.yaml
@@ -13,7 +13,7 @@
 #@ traefik_host_static = data.values.traefik_host_static
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_anti_hotlink = data.values.enable_anti_hotlink == "true"
 #@ anti_hotlink_referers_extra = data.values.anti_hotlink_referers_extra
 #@ anti_hotlink_allow_empty_referer = data.values.anti_hotlink_allow_empty_referer

--- a/xbs/docker-compose.instance.yaml
+++ b/xbs/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"

--- a/yourls/docker-compose.instance.yaml
+++ b/yourls/docker-compose.instance.yaml
@@ -12,7 +12,7 @@
 #@ traefik_host = data.values.traefik_host
 #@ ip_sourcerange = data.values.ip_sourcerange
 #@ enable_http_auth = len(data.values.http_auth.strip()) > 0
-#@ http_auth = data.values.http_auth_var
+#@ http_auth = data.values.http_auth
 #@ enable_oauth2 = data.values.oauth2 == "true"
 #@ authorized_group = data.values.authorized_group
 #@ enable_mtls_auth = data.values.enable_mtls_auth == "true"


### PR DESCRIPTION
## Summary
- Renames `data.values.http_auth_var` to `data.values.http_auth` across all 69 `docker-compose.instance.yaml` templates
- Also renames `pull_http_auth_var` to `pull_http_auth` in registry

## Why

Each project's Makefile passes two related values to `docker_compose_override`:

- `http_auth=PROJECT_HTTP_AUTH` — resolves the value from the .env file (used for the `enable_http_auth` length check)
- `http_auth_var=@PROJECT_HTTP_AUTH` — passes the literal string `${PROJECT_HTTP_AUTH}` (used in the docker label so compose can expand it at runtime)

The instance templates were using `http_auth_var` for the basicauth label, but `http_auth` (the resolved value) works equally well there — ytt embeds it directly into the generated override yaml. This eliminates the redundant `_var` indirection and simplifies the template: one data value serves both the enable check and the label value.

The `http_auth_var` parameter is still passed by Makefiles (harmlessly ignored by the template), so no Makefile changes are needed.

Depends on #628

Closes #630

## Test plan
- [ ] Run `make config` + `make install` on any project and verify the generated override yaml has correct basicauth labels