### PR TITLE
Add NixOS workstation USB image builder and installer

### DIFF
--- a/WORKSTATION_USB.md
+++ b/WORKSTATION_USB.md
@@ -1,0 +1,442 @@
+# Workstation USB
+
+Build a bootable NixOS USB drive that bundles everything needed to
+deploy and manage d.rymcg.tech infrastructure without internet access:
+all workstation tools, a sway desktop environment, read-only reference
+copies of all git repos (with full history), the Docker image archive,
+OS installation ISOs, and Docker CE offline installer packages.
+
+## Why a USB workstation?
+
+In air-gapped or disaster-recovery scenarios, you need a complete
+workstation that can bootstrap servers from scratch — without depending
+on package repositories, container registries, or even a network
+connection. This USB drive is a self-contained ops environment: boot
+any x86_64 machine, log in, and start deploying.
+
+## Architecture
+
+The system is a **mutable NixOS** installation on a USB drive. You can
+`nixos-rebuild switch`, install packages, and make changes like any
+normal NixOS system. Bundled reference data (git repos, Docker image
+archive, ISOs, Docker CE packages) is stored in the nix store and
+protected by GC roots so routine garbage collection won't remove it.
+
+The build uses a **two-phase approach**: Nix builds the OS closure
+(fast, ~10 GB), then a post-install step copies the large archive data
+(~64 GB) into the USB's nix store. This avoids hashing tens of
+gigabytes during flake evaluation.
+
+**Username is baked at build time.** Both `workstation-usb-image` and
+`workstation-usb-install` prompt for a username before building. The
+username is written to `settings.nix`, then the entire NixOS closure
+is built with it. The default password equals the username (via
+`initialPassword`). Clones are exact copies — no account setup, no
+variant builds, no first-boot configuration service.
+
+On first boot, a systemd service clones writable copies of
+d.rymcg.tech and sway-home from the bundled bare repos into
+`~/git/vendor/enigmacurry/`, with GitHub remotes already configured.
+The `_archive/` directory is symlinked to `/var/workstation/` so all
+d.rymcg.tech tools work seamlessly with the nix store data.
+
+A `nixos-rebuild` wrapper is installed so that `sudo nixos-rebuild
+switch` works out of the box — it automatically passes the correct
+`--flake` and `--override-input` flags.
+
+## Customization (settings.nix)
+
+All per-user settings live in `nix/workstation/settings.nix`:
+
+```nix
+{
+  userName = "user";
+  sudoUser = true;
+  remotes = {
+    "d.rymcg.tech" = "https://github.com/EnigmaCurry/d.rymcg.tech.git";
+    "sway-home" = "https://github.com/EnigmaCurry/sway-home.git";
+    "emacs" = "https://github.com/EnigmaCurry/emacs.git";
+    "blog.rymcg.tech" = "https://github.com/EnigmaCurry/blog.rymcg.tech.git";
+    "org" = "https://github.com/EnigmaCurry/org.git";
+  };
+}
+```
+
+| Setting | Description |
+|---------|-------------|
+| `userName` | Login username (default password = username) |
+| `sudoUser` | Whether the user gets sudo (wheel group) |
+| `remotes` | Git remote URLs for all vendor repos |
+
+The build scripts prompt for a username and update `settings.nix`
+automatically. After customization, `git update-index
+--skip-worktree` is applied so local changes don't appear in `git
+status` while remaining visible to the Nix flake evaluator.
+
+To edit settings manually:
+
+```bash
+# Edit settings
+vi nix/workstation/settings.nix
+
+# Hide from git status
+git update-index --skip-worktree nix/workstation/settings.nix
+
+# Undo if needed
+git update-index --no-skip-worktree nix/workstation/settings.nix
+```
+
+## Prerequisites
+
+ * A Linux workstation with [Nix](https://nixos.org/download/) installed
+ * A completed [image archive](ARCHIVE.md) at `_archive/images/x86_64/`
+ * A 128+ GB USB drive (see [size estimates](#size-estimates))
+
+## Commands
+
+All workstation USB commands are available through the `d.rymcg.tech`
+CLI. Every command accepts `--help` for full usage details.
+
+```bash
+d.rymcg.tech workstation-usb-image                    # build raw disk image
+d.rymcg.tech workstation-usb-test-vm                  # test image in a QEMU VM
+d.rymcg.tech workstation-usb-install /dev/sdX          # direct install to USB
+d.rymcg.tech workstation-usb-clone /dev/sdX            # clone booted USB to another device
+```
+
+## Install methods
+
+### Method 1: Direct install to USB device
+
+The simplest approach. Partitions, formats, installs NixOS, and copies
+archive data in one step.
+
+```bash
+d.rymcg.tech workstation-usb-install /dev/sdX
+```
+
+This will:
+1. Present an interactive archive category selector
+2. Prompt for username (default: `user`)
+3. Build the NixOS system closure with that username baked in
+4. Partition the USB (1 GB ESP + rest ext4)
+5. Install NixOS via `nixos-install`
+6. Copy selected archive data into the USB's nix store
+7. Pre-download emacs packages and Rust toolchain for air-gapped use
+
+Default password matches the username. Change it on first boot with
+`passwd`.
+
+### Method 2: Build a disk image
+
+Build a raw `.img` file that can be written to any USB drive with `dd`.
+Uses loop devices (requires sudo) instead of a QEMU VM.
+
+By default, the image includes all archive data (Docker images, ISOs,
+Docker CE packages) found in `_archive/`. An interactive category
+selector lets you choose which archive categories to include, so you
+can skip large items like AI/ML images (~43 GB) to build a smaller
+image. The image size is auto-calculated to fit the selected data
+plus headroom.
+
+```bash
+# Build the full image (includes archive data, auto-sized)
+d.rymcg.tech workstation-usb-image
+
+# Write to USB
+sudo dd if=_archive/workstation-usb.img of=/dev/sdX bs=4M status=progress conv=fsync
+```
+
+The build prompts for a username before building. The category
+selector presents four groups, all selected by default:
+
+ * **Docker images: AI/ML** (~43 GB) — comfyui, open-webui, invokeai,
+   ollama, kokoro
+ * **Docker images: Services** (~21 GB) — everything else
+ * **OS images / ISOs** (~7 GB)
+ * **Docker CE packages** (~200 MB)
+
+If AI/ML images are selected and ComfyUI is present, a follow-up
+prompt lets you choose which GPU variants to include (ROCm, CUDA,
+Intel, CPU).
+
+To build a smaller base image without archive data:
+
+```bash
+# Build base OS only (~10 GB, skips category selection)
+d.rymcg.tech workstation-usb-image --base-only
+
+# Write to USB
+sudo dd if=_archive/workstation-usb-base.img of=/dev/sdX bs=4M status=progress conv=fsync
+
+# Copy archive data separately
+sudo mount /dev/sdX2 /mnt && sudo mount /dev/sdX1 /mnt/boot
+d.rymcg.tech workstation-usb-post-install /mnt
+sudo umount -R /mnt
+```
+
+| Option | Description |
+|--------|-------------|
+| `--size SIZE` | Override auto-calculated image size (e.g. `128G`) |
+| `--output FILE` | Output path (default: `_archive/workstation-usb.img`) |
+| `--base-only` | Build OS only, without archive data (smaller image) |
+| `--dry-run` | Build system closure only, skip image creation |
+
+On first boot, the root partition automatically expands to fill the
+USB drive.
+
+### Method 3: Clone from a booted USB
+
+Once you have a working workstation USB, you can clone it to another
+drive directly — no build host, network access, or `nix build`
+required. The clone reuses the running system closure from
+`/run/current-system` and copies archive GC roots from the booted
+USB's nix store. Clones are exact copies with the same username and
+configuration.
+
+```bash
+# On the booted workstation USB, with a second drive attached:
+d.rymcg.tech workstation-usb-clone /dev/sdX
+
+# Or install base OS only, without archive data:
+d.rymcg.tech workstation-usb-clone --base-only /dev/sdX
+```
+
+The `workstation-usb-clone` command is also available directly in PATH
+on the booted USB (installed via `environment.systemPackages`), so it
+works even without the writable repo clone.
+
+This will:
+1. Resolve the system closure from `/run/current-system`
+2. Confirm device erase
+3. Partition the target (1 GB ESP + rest ext4)
+4. Install NixOS via `nixos-install --system`
+5. Copy all `workstation-usb-*` GC roots to the target's nix store
+6. Run chroot tasks (emacs packages, Rust toolchain)
+7. Copy home directory resources (Rust toolchain, emacs packages,
+   fonts) from the booted USB
+
+### Testing with a VM
+
+After building an image, you can boot it in a QEMU virtual machine to
+verify everything works before writing to a USB drive. The VM uses a
+CoW (copy-on-write) overlay, so the original image is never modified.
+
+```bash
+# Test the full image
+d.rymcg.tech workstation-usb-test-vm
+
+# Test the base-only image
+d.rymcg.tech workstation-usb-test-vm --base
+
+# Test in air-gapped mode (no network)
+d.rymcg.tech workstation-usb-test-vm --no-network
+
+# SSH into the running VM
+ssh -o StrictHostKeyChecking=no -p 10022 user@localhost
+```
+
+| Option | Description |
+|--------|-------------|
+| `--image FILE` | Disk image path (default: auto-detected) |
+| `--base` | Use the base-only image |
+| `--memory MB` | RAM in MB (default: 4096) |
+| `--cpus N` | Number of CPUs (default: all cores) |
+| `--ssh-port PORT` | Host SSH port forwarding (default: 10022) |
+| `--no-network` | Disable networking (simulate air-gapped environment) |
+| `--display TYPE` | QEMU display: `gtk`, `sdl`, `none` (default: `gtk`) |
+
+Requires OVMF firmware for UEFI boot and KVM for hardware
+acceleration.
+
+## What's on the USB
+
+### System
+
+ * NixOS with the latest kernel and broad hardware support
+ * Sway window manager with greetd/tuigreet login
+ * PipeWire audio
+ * NetworkManager for WiFi/Ethernet
+ * Firefox with extensions (uBlock Origin, Dark Reader, Vimium,
+   Multi-Account Containers, Temporary Containers), DuckDuckGo
+   default search, telemetry disabled, HTTPS-only mode
+ * Thunar file manager with volume management
+ * Flatpak with Flathub (Bazaar pre-installed)
+ * Docker daemon (installed but disabled on boot; enable with
+   `sudo systemctl start docker`)
+ * libvirtd / virt-manager / QEMU for VM management
+ * All d.rymcg.tech required tools plus development utilities
+ * Full sway-home environment (emacs with pre-downloaded packages,
+   tmux, shell config, etc.)
+ * Rust toolchain (stable, pre-installed with rust-src,
+   rust-analyzer, clippy, rustfmt)
+ * Network diagnostics (nmap, tcpdump, mtr, socat, step-cli, rclone)
+ * Disk/recovery tools (ddrescue, testdisk, smartmontools, ntfs3g)
+ * Serial console tools (minicom, picocom, ipmitool)
+ * Crypto/security tools (gnupg, age, pass)
+
+### Bundled data (in nix store, GC-rooted)
+
+ * Bare git repos with full history:
+   d.rymcg.tech, sway-home, emacs, blog.rymcg.tech, org
+   (nixos-vm-template is provided by sway-home)
+ * Writable clones of d.rymcg.tech and sway-home (created on first
+   boot from bare repos, with remotes from `settings.nix`)
+ * Docker image archive (~64 GB, ~170 images):
+   AI/ML (~43 GB), Services (~21 GB)
+ * Debian, Fedora, and Raspberry Pi OS images (~8 GB)
+ * Docker CE .deb/.rpm packages for Debian, Raspberry Pi OS,
+   and Fedora (~0.5 GB)
+
+### User account
+
+A single user account is created with the username chosen at build
+time. The user has sudo (wheel group) by default. Default password
+matches the username — change it on first boot with `passwd`.
+
+## Using the USB workstation
+
+### Rebuild the system
+
+`nixos-rebuild switch` works out of the box:
+
+```bash
+sudo nixos-rebuild switch
+```
+
+The installed `nixos-rebuild` is a wrapper that automatically passes
+`--flake` and `--override-input` flags pointing at the local
+d.rymcg.tech repo.
+
+### Check bundled data
+
+```bash
+workstation-usb-info
+```
+
+Shows what archive data is installed, including image count and sizes.
+
+### Clone to another drive
+
+```bash
+workstation-usb-clone /dev/sdX
+```
+
+Clone the entire workstation (OS + archive data) to another USB drive
+or disk. No network or build tools required. See
+[Method 3](#method-3-clone-from-a-booted-usb) above.
+
+### Restore Docker images to a server
+
+```bash
+workstation-usb-restore-images
+```
+
+This wraps `d.rymcg.tech image-restore` with the correct archive
+directory pointed at the nix store.
+
+### Install Docker on a server
+
+```bash
+d.rymcg.tech install-docker
+```
+
+Interactive installer that supports both online (get.docker.com) and
+offline (bundled .deb/.rpm packages) installation, for both local and
+remote Docker contexts.
+
+### Access bundled data
+
+Archive data is stored under `/var/workstation/` and symlinked into
+the bundled d.rymcg.tech repo so tools work seamlessly:
+
+```
+~/git/vendor/enigmacurry/d.rymcg.tech/_archive -> /var/workstation
+```
+
+| Path | Contents |
+|------|----------|
+| `/var/workstation/images/x86_64/` | Docker image `.tar.gz` files |
+| `/var/workstation/isos/` | Debian, Fedora, and Raspberry Pi OS images |
+| `/var/workstation/docker-packages/` | Docker CE `.deb`/`.rpm` files |
+
+### Remove bundled archive data
+
+If you no longer need the bundled archive data (Docker images, ISOs,
+Docker CE packages), you can free the space by removing the GC root
+symlinks and running garbage collection:
+
+```bash
+sudo rm /nix/var/nix/gcroots/workstation-usb-*
+sudo nix-collect-garbage
+```
+
+### Access git repos
+
+Read-only bare repos are in the nix store, symlinked into the user's
+home directory:
+
+```
+~/git/vendor-nix/enigmacurry/d.rymcg.tech     (bare, read-only)
+~/git/vendor-nix/enigmacurry/sway-home         (bare, read-only)
+~/git/vendor-nix/enigmacurry/emacs             (bare, read-only)
+~/git/vendor-nix/enigmacurry/blog.rymcg.tech   (bare, read-only)
+~/git/vendor-nix/enigmacurry/org               (bare, read-only)
+```
+
+Writable clones are created automatically on first boot:
+
+```
+~/git/vendor/enigmacurry/d.rymcg.tech          (writable, full history)
+~/git/vendor/enigmacurry/sway-home             (writable, full history)
+```
+
+To create writable clones of the other repos:
+
+```bash
+git clone ~/git/vendor-nix/enigmacurry/emacs ~/git/vendor/enigmacurry/emacs
+git clone ~/git/vendor-nix/enigmacurry/blog.rymcg.tech ~/git/vendor/enigmacurry/blog.rymcg.tech
+git clone ~/git/vendor-nix/enigmacurry/org ~/git/vendor/enigmacurry/org
+```
+
+## Size estimates
+
+| Component | Size |
+|-----------|------|
+| NixOS system + all packages | ~5 GB |
+| sway-home packages (emacs, dev tools) | ~3 GB |
+| Git repos in nix store | ~50 MB |
+| Docker images: AI/ML | ~43 GB |
+| Docker images: Services | ~21 GB |
+| ISOs (Debian + Fedora + Raspberry Pi OS) | ~8 GB |
+| Docker CE packages (.deb + .rpm) | ~0.5 GB |
+| Operating headroom | ~5 GB |
+| **Total (all categories)** | **~86 GB** |
+| **Total (services only, no AI/ML)** | **~43 GB** |
+
+A 128 GB USB drive is recommended. A 256 GB drive provides ample room
+for additional data.
+
+## NixOS module layout
+
+```
+flake.nix                              # Top-level flake
+nix/workstation/
+  settings.nix                         # Username, sudo, repo remote URLs
+  configuration.nix                    # Main config (imports all modules)
+  hardware.nix                         # Hardware support, filesystems
+  boot.nix                            # UEFI systemd-boot, growpart
+  users.nix                           # User account (from settings.nix)
+  networking.nix                      # NetworkManager, firewall
+  docker.nix                          # Docker + libvirtd (Docker disabled on boot)
+  desktop.nix                         # Sway, greetd, PipeWire, Firefox, Thunar, Flatpak
+  home-manager.nix                    # sway-home, Firefox extensions, Flatpak apps
+  workstation-packages.nix            # CLI tools, dev tools, nixos-install-tools
+  first-boot.nix                      # Flake input pinning, nixos-rebuild wrapper
+  repos.nix                           # Bare git repos, writable clone service
+  archive.nix                         # GC roots, helper scripts (info, clone, restore)
+  installer/
+    install-to-device.sh              # Direct install script
+    clone-to-device.sh                # Clone from booted USB script
+    post-install.sh                   # Archive data copy + chroot tasks
+```

--- a/_scripts/workstation-build-lib.sh
+++ b/_scripts/workstation-build-lib.sh
@@ -1,0 +1,332 @@
+#!/bin/bash
+## Shared library for workstation build scripts (USB image + install-to-device)
+## Source this after funcs.sh. Expects BIN and ROOT_DIR to be set.
+
+AI_ML_PROJECTS=(comfyui open-webui invokeai ollama kokoro)
+
+## Pre-flight check: show what will be included and offer to fetch missing data.
+## Expects ARCHIVE_SOURCE to be set by the caller.
+## Sets ARCHIVE_IMG_DIR, ISOS_DIR, DOCKER_PKG_DIR.
+workstation_archive_preflight() {
+    echo "=== Pre-flight check ==="
+    echo ""
+    MISSING=()
+
+    # Check Docker image archive
+    ARCHIVE_IMG_DIR="${ARCHIVE_SOURCE}/images/x86_64"
+    if [[ -d "$ARCHIVE_IMG_DIR" ]] && [[ -n "$(ls -A "$ARCHIVE_IMG_DIR" 2>/dev/null)" ]]; then
+        count=$(find "$ARCHIVE_IMG_DIR" -name '*.tar.gz' 2>/dev/null | wc -l)
+        size=$(du -sh "$ARCHIVE_IMG_DIR" | cut -f1)
+        echo "  [x] Docker image archive: $count images ($size)"
+    else
+        echo "  [ ] Docker image archive: not found"
+        MISSING+=("images")
+    fi
+
+    # Check ISOs
+    ISOS_DIR="${ARCHIVE_SOURCE}/isos"
+    if [[ -d "$ISOS_DIR" ]] && [[ -n "$(ls -A "$ISOS_DIR" 2>/dev/null)" ]]; then
+        count=$(ls "$ISOS_DIR" | wc -l)
+        size=$(du -sh "$ISOS_DIR" | cut -f1)
+        echo "  [x] OS images (ISOs): $count files ($size)"
+    else
+        echo "  [ ] OS images (ISOs): not found"
+        MISSING+=("isos")
+    fi
+
+    # Check Docker CE packages
+    DOCKER_PKG_DIR="${ARCHIVE_SOURCE}/docker-packages"
+    if [[ -d "$DOCKER_PKG_DIR" ]] && [[ -n "$(ls -A "$DOCKER_PKG_DIR" 2>/dev/null)" ]]; then
+        count=$(find "$DOCKER_PKG_DIR" -name '*.deb' -o -name '*.rpm' 2>/dev/null | wc -l)
+        size=$(du -sh "$DOCKER_PKG_DIR" | cut -f1)
+        echo "  [x] Docker CE packages: $count packages ($size)"
+    else
+        echo "  [ ] Docker CE packages: not found"
+        MISSING+=("docker-packages")
+    fi
+
+    echo ""
+
+    if [[ ${#MISSING[@]} -gt 0 ]]; then
+        echo "Some archive data is missing. The image will be built without it"
+        echo "unless you download it now."
+        echo ""
+        for item in "${MISSING[@]}"; do
+            case "$item" in
+                images)
+                    if confirm no "Download Docker image archive? (requires d.rymcg.tech image-archive)"; then
+                        d.rymcg.tech image-archive --fail-fast --delete --verbose
+                    fi
+                    ;;
+                isos)
+                    if confirm yes "Download OS images (ISOs)?"; then
+                        d.rymcg.tech workstation-usb-download-isos
+                    fi
+                    ;;
+                docker-packages)
+                    if confirm yes "Download Docker CE packages?"; then
+                        d.rymcg.tech workstation-usb-download-docker-packages
+                    fi
+                    ;;
+            esac
+        done
+        echo ""
+    else
+        echo "All archive data present."
+        echo ""
+    fi
+}
+
+## Interactive archive category selection + ComfyUI variant picker + manifest generation.
+## Expects ARCHIVE_IMG_DIR, ISOS_DIR, DOCKER_PKG_DIR, ARCHIVE_SOURCE to be set.
+## Sets MANIFEST_FILE, SELECTED_IMAGE_PROJECTS, COMFYUI_SELECTED_FILES,
+## INCLUDE_AI_ML, INCLUDE_SERVICES, INCLUDE_ISOS, INCLUDE_DOCKER_PACKAGES.
+workstation_archive_select() {
+    CATEGORY_LABELS=()
+    CATEGORY_KEYS=()
+
+    # Measure AI/ML images
+    _AI_ML_SIZE=0
+    _AI_ML_FOUND=false
+    for proj in "${AI_ML_PROJECTS[@]}"; do
+        proj_dir="$ARCHIVE_IMG_DIR/$proj"
+        if [[ -d "$proj_dir" ]] && [[ -n "$(ls -A "$proj_dir" 2>/dev/null)" ]]; then
+            _AI_ML_FOUND=true
+            _AI_ML_SIZE=$((_AI_ML_SIZE + $(du -sb "$proj_dir" | cut -f1)))
+        fi
+    done
+    if $_AI_ML_FOUND; then
+        _ai_ml_gb=$(awk "BEGIN {printf \"%.1f\", $_AI_ML_SIZE / 1073741824}")
+        CATEGORY_LABELS+=("Docker images: AI/ML ($_ai_ml_gb GB)")
+        CATEGORY_KEYS+=("ai_ml")
+    fi
+
+    # Measure service images (everything not in AI_ML_PROJECTS)
+    _SERVICES_SIZE=0
+    _SERVICES_FOUND=false
+    if [[ -d "$ARCHIVE_IMG_DIR" ]]; then
+        for proj_dir in "$ARCHIVE_IMG_DIR"/*/; do
+            [[ -d "$proj_dir" ]] || continue
+            proj_name=$(basename "$proj_dir")
+            if ! element_in_array "$proj_name" "${AI_ML_PROJECTS[@]}"; then
+                if [[ -n "$(ls -A "$proj_dir" 2>/dev/null)" ]]; then
+                    _SERVICES_FOUND=true
+                    _SERVICES_SIZE=$((_SERVICES_SIZE + $(du -sb "$proj_dir" | cut -f1)))
+                fi
+            fi
+        done
+    fi
+    if $_SERVICES_FOUND; then
+        _services_gb=$(awk "BEGIN {printf \"%.1f\", $_SERVICES_SIZE / 1073741824}")
+        CATEGORY_LABELS+=("Docker images: Services ($_services_gb GB)")
+        CATEGORY_KEYS+=("services")
+    fi
+
+    # Measure ISOs
+    if [[ -d "$ISOS_DIR" ]] && [[ -n "$(ls -A "$ISOS_DIR" 2>/dev/null)" ]]; then
+        _isos_bytes=$(du -sb "$ISOS_DIR" | cut -f1)
+        _isos_gb=$(awk "BEGIN {printf \"%.1f\", $_isos_bytes / 1073741824}")
+        CATEGORY_LABELS+=("OS images / ISOs ($_isos_gb GB)")
+        CATEGORY_KEYS+=("isos")
+    fi
+
+    # Measure Docker CE packages
+    if [[ -d "$DOCKER_PKG_DIR" ]] && [[ -n "$(ls -A "$DOCKER_PKG_DIR" 2>/dev/null)" ]]; then
+        _docker_pkg_bytes=$(du -sb "$DOCKER_PKG_DIR" | cut -f1)
+        _docker_pkg_mb=$(awk "BEGIN {printf \"%.0f\", $_docker_pkg_bytes / 1048576}")
+        CATEGORY_LABELS+=("Docker CE packages ($_docker_pkg_mb MB)")
+        CATEGORY_KEYS+=("docker_packages")
+    fi
+
+    if [[ ${#CATEGORY_LABELS[@]} -gt 0 ]]; then
+        echo "=== Select archive categories ==="
+        echo "Deselect categories you don't need to reduce image size."
+        echo ""
+
+        # All selected by default
+        _DEFAULT_JSON=$(printf '%s\n' "${CATEGORY_LABELS[@]}" | jq -R . | jq -s -c .)
+        _exit_code=0
+        SELECTED_OUTPUT=$(wizard select --cancel-code=2 --default "$_DEFAULT_JSON" \
+            "Select categories to include:" "${CATEGORY_LABELS[@]}") && _exit_code=$? || _exit_code=$?
+        if [[ "$_exit_code" == "2" ]]; then
+            cancel
+        fi
+        readarray -t SELECTED <<< "$SELECTED_OUTPUT"
+
+        # Determine what was selected
+        INCLUDE_AI_ML=false
+        INCLUDE_SERVICES=false
+        INCLUDE_ISOS=false
+        INCLUDE_DOCKER_PACKAGES=false
+
+        for sel in "${SELECTED[@]}"; do
+            case "$sel" in
+                "Docker images: AI/ML"*) INCLUDE_AI_ML=true ;;
+                "Docker images: Services"*) INCLUDE_SERVICES=true ;;
+                "OS images / ISOs"*) INCLUDE_ISOS=true ;;
+                "Docker CE packages"*) INCLUDE_DOCKER_PACKAGES=true ;;
+            esac
+        done
+
+        ## ComfyUI GPU variant selection
+        COMFYUI_SELECTED_FILES=()
+        COMFYUI_DIR="$ARCHIVE_IMG_DIR/comfyui"
+        if $INCLUDE_AI_ML && [[ -d "$COMFYUI_DIR" ]] && [[ -n "$(ls -A "$COMFYUI_DIR" 2>/dev/null)" ]]; then
+            VARIANT_LABELS=()
+            VARIANT_FILES=()
+            for f in "$COMFYUI_DIR"/comfyui-comfyui-*_d-rymcg-tech-*.tar.gz; do
+                [[ -f "$f" ]] || continue
+                fname=$(basename "$f")
+                variant=$(echo "$fname" | sed 's/comfyui-comfyui-\(.*\)_d-rymcg-tech-[0-9]*\.tar\.gz/\1/')
+                case "$variant" in
+                    rocm) variant_label="ROCm" ;;
+                    cuda) variant_label="CUDA" ;;
+                    intel) variant_label="Intel" ;;
+                    cpu) variant_label="CPU" ;;
+                    *) variant_label="$variant" ;;
+                esac
+                file_size=$(du -sh "$f" | cut -f1)
+                VARIANT_LABELS+=("ComfyUI $variant_label ($file_size)")
+                VARIANT_FILES+=("$fname")
+            done
+
+            if [[ ${#VARIANT_LABELS[@]} -gt 1 ]]; then
+                echo ""
+                _VARIANT_DEFAULT_JSON=$(printf '%s\n' "${VARIANT_LABELS[@]}" | jq -R . | jq -s -c .)
+                _exit_code=0
+                VARIANT_OUTPUT=$(wizard select --cancel-code=2 --default "$_VARIANT_DEFAULT_JSON" \
+                    "Select ComfyUI GPU variants:" "${VARIANT_LABELS[@]}") && _exit_code=$? || _exit_code=$?
+                if [[ "$_exit_code" == "2" ]]; then
+                    cancel
+                fi
+                readarray -t SELECTED_VARIANTS <<< "$VARIANT_OUTPUT"
+
+                for i in "${!VARIANT_LABELS[@]}"; do
+                    for sel in "${SELECTED_VARIANTS[@]}"; do
+                        if [[ "$sel" == "${VARIANT_LABELS[$i]}" ]]; then
+                            COMFYUI_SELECTED_FILES+=("${VARIANT_FILES[$i]}")
+                        fi
+                    done
+                done
+            else
+                # Only one variant available, include it
+                COMFYUI_SELECTED_FILES=("${VARIANT_FILES[@]}")
+            fi
+        fi
+
+        ## Build archive selection manifest
+        SELECTED_IMAGE_PROJECTS=()
+        if $INCLUDE_AI_ML; then
+            for proj in "${AI_ML_PROJECTS[@]}"; do
+                [[ "$proj" == "comfyui" ]] && continue
+                proj_dir="$ARCHIVE_IMG_DIR/$proj"
+                [[ -d "$proj_dir" ]] && [[ -n "$(ls -A "$proj_dir" 2>/dev/null)" ]] && SELECTED_IMAGE_PROJECTS+=("$proj")
+            done
+        fi
+        if $INCLUDE_SERVICES; then
+            for proj_dir in "$ARCHIVE_IMG_DIR"/*/; do
+                [[ -d "$proj_dir" ]] || continue
+                proj_name=$(basename "$proj_dir")
+                if ! element_in_array "$proj_name" "${AI_ML_PROJECTS[@]}"; then
+                    [[ -n "$(ls -A "$proj_dir" 2>/dev/null)" ]] && SELECTED_IMAGE_PROJECTS+=("$proj_name")
+                fi
+            done
+        fi
+
+        MANIFEST_FILE=$(mktemp)
+        {
+            echo "ARCHIVE_ROOT=\"$ARCHIVE_SOURCE\""
+            echo "IMAGE_PROJECTS=\"${SELECTED_IMAGE_PROJECTS[*]}\""
+            echo "COMFYUI_FILES=\"${COMFYUI_SELECTED_FILES[*]}\""
+            echo "INCLUDE_ISOS=$INCLUDE_ISOS"
+            echo "INCLUDE_DOCKER_PACKAGES=$INCLUDE_DOCKER_PACKAGES"
+        } > "$MANIFEST_FILE"
+        echo ""
+    fi
+}
+
+## Prompt for hostname and username, updating settings.nix if changed.
+## Expects ROOT_DIR to be set.
+## IMPORTANT: --skip-worktree must NOT be set until after `nix build`,
+## because nix flakes treat a skip-worktree file as unchanged (uses the
+## committed content). Call workstation_hide_settings after the build.
+workstation_configure_settings() {
+    local settings_file="$ROOT_DIR/nix/workstation/settings.nix"
+
+    # Temporarily clear skip-worktree so nix sees the working tree content
+    git -C "$ROOT_DIR" update-index --no-skip-worktree nix/workstation/settings.nix 2>/dev/null || true
+
+    local current_host
+    current_host=$(grep 'hostName' "$settings_file" | sed 's/.*"\(.*\)".*/\1/')
+    local current_user
+    current_user=$(grep 'userName' "$settings_file" | sed 's/.*"\(.*\)".*/\1/')
+
+    if [[ ! -t 0 ]]; then
+        # Non-interactive: use current settings.nix values as-is
+        echo ""
+        echo "=== System configuration (non-interactive, using defaults) ==="
+        echo "Hostname: $current_host"
+        echo "Admin username: $current_user"
+        return
+    fi
+
+    echo ""
+    echo "=== System configuration ==="
+
+    read -e -p "Hostname [$current_host]: " ws_host
+    ws_host="${ws_host:-$current_host}"
+    if [[ "$ws_host" != "$current_host" ]]; then
+        sed -i "s/hostName = \"$current_host\"/hostName = \"$ws_host\"/" "$settings_file"
+        echo "Updated settings.nix: hostName = \"$ws_host\""
+    fi
+
+    echo ""
+    echo "=== Admin user account ==="
+    echo "This account has sudo (wheel group). Password = username."
+    echo "(This is fine for a USB stick — change it after installing to a real system.)"
+    read -e -p "Admin username [$current_user]: " ws_user
+    ws_user="${ws_user:-$current_user}"
+    if [[ "$ws_user" != "$current_user" ]]; then
+        sed -i "s/userName = \"$current_user\"/userName = \"$ws_user\"/" "$settings_file"
+        echo "Updated settings.nix: userName = \"$ws_user\""
+    fi
+}
+
+## Hide settings.nix from git status. Call AFTER nix build completes.
+## Expects ROOT_DIR to be set.
+workstation_hide_settings() {
+    git -C "$ROOT_DIR" update-index --skip-worktree nix/workstation/settings.nix
+}
+
+## Read a remote URL from settings.nix.
+## Expects ROOT_DIR to be set.
+## Usage: workstation_remote "repo-name"
+workstation_remote() {
+    nix eval --raw --file "$ROOT_DIR/nix/workstation/settings.nix" "remotes.\"$1\""
+}
+
+## Create bare git repo clones in a temp directory.
+## Expects ROOT_DIR to be set.
+## Sets BARE_DIR.
+workstation_create_bare_repos() {
+    echo "=== Creating bare git repo clones ==="
+    BARE_DIR=$(mktemp -d)/vendor-git-repos
+    mkdir -p "$BARE_DIR"
+    git clone --bare "$(git -C "${ROOT_DIR}" rev-parse --show-toplevel)" "$BARE_DIR/d.rymcg.tech"
+    git clone --bare "$(workstation_remote sway-home)" "$BARE_DIR/sway-home"
+    git clone --bare "$(workstation_remote emacs)" "$BARE_DIR/emacs"
+    git clone --bare "$(workstation_remote blog.rymcg.tech)" "$BARE_DIR/blog.rymcg.tech"
+    git clone --bare "$(workstation_remote org)" "$BARE_DIR/org"
+    echo "Bare repos created in $BARE_DIR"
+}
+
+## Run nix build with --override-input vendor-git-repos.
+## Expects ROOT_DIR and BARE_DIR to be set.
+## Usage: workstation_nix_build FLAKE_ATTR
+## Prints the output path to stdout.
+workstation_nix_build() {
+    local flake_attr="$1"
+    nix build "${ROOT_DIR}#${flake_attr}" \
+        --override-input vendor-git-repos "path:${BARE_DIR}" \
+        --no-link --print-out-paths
+}

--- a/_scripts/workstation-usb-clone
+++ b/_scripts/workstation-usb-clone
@@ -1,0 +1,74 @@
+#!/bin/bash
+## Clone the booted workstation USB to another device
+set -eo pipefail
+
+BIN=$(dirname $(realpath ${BASH_SOURCE}))
+ROOT_DIR=$(dirname ${BIN})
+source ${BIN}/funcs.sh
+
+usage() {
+    echo "Usage: d.rymcg.tech workstation-usb-clone [OPTIONS] /dev/sdX"
+    echo ""
+    echo "Clone this booted workstation USB to another device."
+    echo "No build or network access required — reuses the running system closure."
+    echo ""
+    echo "WARNING: This will ERASE ALL DATA on the target device."
+    echo ""
+    echo "Options:"
+    echo "  --base-only  Install OS only, without archive data"
+    echo "  -h, --help   Show this help"
+}
+
+DEVICE=""
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --base-only)
+            EXTRA_ARGS+=("--base-only")
+            shift
+            ;;
+        -*)
+            echo "Error: unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+        *)
+            if [[ -z "$DEVICE" ]]; then
+                DEVICE="$1"
+            else
+                echo "Error: unexpected argument: $1" >&2
+                usage >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$DEVICE" ]]; then
+    echo "Error: No device specified." >&2
+    usage >&2
+    exit 1
+fi
+
+# Find the clone script — prefer the repo copy, fall back to nix store
+CLONE_SCRIPT="${ROOT_DIR}/nix/workstation/installer/clone-to-device.sh"
+if [[ ! -x "$CLONE_SCRIPT" ]]; then
+    # Running from the nix-wrapped version; locate via the nix store
+    CLONE_SCRIPT="$(dirname "$(readlink -f /run/current-system)")/../../nix/workstation/installer/clone-to-device.sh" 2>/dev/null || true
+fi
+if [[ ! -x "$CLONE_SCRIPT" ]]; then
+    echo "Error: clone-to-device.sh not found." >&2
+    exit 1
+fi
+
+if [[ $EUID -ne 0 ]]; then
+    exec sudo bash -c "export PATH=\"$PATH:\$PATH\"; exec \"$CLONE_SCRIPT\" ${EXTRA_ARGS[*]:+${EXTRA_ARGS[*]}} \"$DEVICE\""
+fi
+
+exec "$CLONE_SCRIPT" "${EXTRA_ARGS[@]}" "$DEVICE"

--- a/_scripts/workstation-usb-download-docker-packages
+++ b/_scripts/workstation-usb-download-docker-packages
@@ -1,0 +1,168 @@
+#!/bin/bash
+## Download Docker CE offline installer packages (.deb and .rpm)
+set -eo pipefail
+
+BIN=$(dirname $(realpath ${BASH_SOURCE}))
+ROOT_DIR=$(dirname ${BIN})
+source ${BIN}/funcs.sh
+
+PKG_DIR="${ROOT_DIR}/_archive/docker-packages"
+
+usage() {
+    echo "Usage: d.rymcg.tech workstation-usb-download-docker-packages [OPTIONS]"
+    echo ""
+    echo "Download Docker CE packages for offline installation."
+    echo "Targets: Debian (amd64), Raspberry Pi OS (arm64), Fedora (x86_64)"
+    echo "Packages are saved to: ${PKG_DIR}"
+    echo ""
+    echo "Options:"
+    echo "  --debian-only    Download only Debian (amd64) packages"
+    echo "  --raspios-only   Download only Raspberry Pi OS (arm64) packages"
+    echo "  --fedora-only    Download only Fedora packages"
+    echo "  --check          Show what would be downloaded"
+    echo "  -h, --help       Show this help"
+}
+
+DOWNLOAD_DEBIAN=true
+DOWNLOAD_RASPIOS=true
+DOWNLOAD_FEDORA=true
+CHECK_ONLY=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --debian-only)
+            DOWNLOAD_RASPIOS=false
+            DOWNLOAD_FEDORA=false
+            shift
+            ;;
+        --raspios-only)
+            DOWNLOAD_DEBIAN=false
+            DOWNLOAD_FEDORA=false
+            shift
+            ;;
+        --fedora-only)
+            DOWNLOAD_DEBIAN=false
+            DOWNLOAD_RASPIOS=false
+            shift
+            ;;
+        --check)
+            CHECK_ONLY=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Docker CE package base URLs
+DOCKER_DEB_BASE="https://download.docker.com/linux/debian/dists/trixie/pool/stable/amd64"
+DOCKER_DEB_ARM64_BASE="https://download.docker.com/linux/debian/dists/trixie/pool/stable/arm64"
+DOCKER_RPM_BASE="https://download.docker.com/linux/fedora/43/x86_64/stable/Packages"
+
+download_pkg() {
+    local url="$1"
+    local dest_dir="$2"
+    local filename
+    filename=$(basename "$url")
+    local dest="$dest_dir/$filename"
+
+    if [[ "$CHECK_ONLY" == "true" ]]; then
+        if [[ -f "$dest" ]]; then
+            echo "  EXISTS: $filename ($(du -h "$dest" | cut -f1))"
+        else
+            echo "  DOWNLOAD: $url"
+        fi
+        return
+    fi
+
+    if [[ -f "$dest" ]]; then
+        echo "  Already downloaded: $filename"
+        return
+    fi
+
+    echo "  Downloading: $filename"
+    curl -fL -o "$dest.partial" --progress-bar "$url" || {
+        echo "  Warning: Failed to download $filename (may not exist yet)" >&2
+        rm -f "$dest.partial"
+        return 1
+    }
+    mv "$dest.partial" "$dest"
+}
+
+fetch_package_list() {
+    local base_url="$1"
+    local ext="$2"
+
+    # Fetch the directory listing and extract package filenames
+    curl -fsSL "$base_url/" 2>/dev/null | \
+        grep -oP "href=\"[^\"]+\.${ext}\"" | \
+        sed 's/href="//;s/"//' | \
+        sort -V
+}
+
+download_latest_packages() {
+    local base_url="$1"
+    local dest_dir="$2"
+    local ext="$3"
+    local packages=("docker-ce" "docker-ce-cli" "containerd.io" "docker-compose-plugin" "docker-buildx-plugin" "docker-ce-rootless-extras")
+
+    mkdir -p "$dest_dir"
+
+    # Get the full package list
+    local all_packages
+    all_packages=$(fetch_package_list "$base_url" "$ext")
+
+    if [[ -z "$all_packages" ]]; then
+        echo "  Warning: Could not fetch package list from $base_url" >&2
+        return 1
+    fi
+
+    # For each required package, download the latest version
+    for pkg in "${packages[@]}"; do
+        local latest
+        latest=$(echo "$all_packages" | grep "^${pkg}_\|^${pkg}-[0-9]" | tail -1)
+        if [[ -n "$latest" ]]; then
+            download_pkg "${base_url}/${latest}" "$dest_dir" || true
+        else
+            echo "  Note: $pkg not found in repository listing"
+        fi
+    done
+}
+
+echo "=== Docker CE Package Downloads ==="
+echo "Directory: $PKG_DIR"
+echo ""
+
+if [[ "$DOWNLOAD_DEBIAN" == "true" ]]; then
+    echo "Debian (trixie/amd64) packages:"
+    DEB_DIR="$PKG_DIR/debian"
+    download_latest_packages "$DOCKER_DEB_BASE" "$DEB_DIR" "deb"
+    echo ""
+fi
+
+if [[ "$DOWNLOAD_RASPIOS" == "true" ]]; then
+    echo "Raspberry Pi OS (trixie/arm64) packages:"
+    RASPIOS_DIR="$PKG_DIR/raspios"
+    download_latest_packages "$DOCKER_DEB_ARM64_BASE" "$RASPIOS_DIR" "deb"
+    echo ""
+fi
+
+if [[ "$DOWNLOAD_FEDORA" == "true" ]]; then
+    echo "Fedora 43 (x86_64) packages:"
+    RPM_DIR="$PKG_DIR/fedora"
+    download_latest_packages "$DOCKER_RPM_BASE" "$RPM_DIR" "rpm"
+    echo ""
+fi
+
+if [[ "$CHECK_ONLY" != "true" ]]; then
+    echo "=== Done ==="
+    echo "Packages saved to: $PKG_DIR"
+    find "$PKG_DIR" -type f \( -name '*.deb' -o -name '*.rpm' \) -exec ls -lh {} \; 2>/dev/null || true
+fi

--- a/_scripts/workstation-usb-download-isos
+++ b/_scripts/workstation-usb-download-isos
@@ -1,0 +1,171 @@
+#!/bin/bash
+## Download OS images (Debian, Fedora, Raspberry Pi OS) for offline workstation use
+set -eo pipefail
+
+BIN=$(dirname $(realpath ${BASH_SOURCE}))
+ROOT_DIR=$(dirname ${BIN})
+source ${BIN}/funcs.sh
+
+ISOS_DIR="${ROOT_DIR}/_archive/isos"
+
+# Directory listings — filenames are auto-discovered from these
+DEBIAN_DIR_URL="https://cdimage.debian.org/debian-cd/current/amd64/iso-dvd/"
+DEBIAN_ISO_PATTERN='debian-[0-9][0-9.]*-amd64-DVD-1\.iso'
+
+FEDORA_RELEASE=43
+FEDORA_DIR_URL="https://download.fedoraproject.org/pub/fedora/linux/releases/${FEDORA_RELEASE}/Server/x86_64/iso/"
+FEDORA_ISO_PATTERN='Fedora-Server-dvd-x86_64-[0-9][0-9.-]*\.iso'
+
+RASPI_IMAGES_URL="https://downloads.raspberrypi.com/raspios_lite_arm64/images/"
+RASPI_SUBDIR_PATTERN='raspios_lite_arm64-[0-9]{4}-[0-9]{2}-[0-9]{2}'
+RASPI_IMAGE_PATTERN='[0-9]{4}-[0-9]{2}-[0-9]{2}-raspios-[a-z]+-arm64-lite\.img\.xz'
+
+# Minimum expected image size (100 MB)
+MIN_IMAGE_BYTES=$((100 * 1024 * 1024))
+
+usage() {
+    echo "Usage: d.rymcg.tech workstation-usb-download-isos [OPTIONS]"
+    echo ""
+    echo "Download OS images for offline use."
+    echo "Filenames are auto-discovered from upstream directories."
+    echo "Images are saved to: ${ISOS_DIR}"
+    echo ""
+    echo "Options:"
+    echo "  --debian-only    Download only Debian ISO"
+    echo "  --fedora-only    Download only Fedora ISO"
+    echo "  --raspi-only     Download only Raspberry Pi OS Lite image"
+    echo "  --check          Show what would be downloaded"
+    echo "  -h, --help       Show this help"
+}
+
+DOWNLOAD_DEBIAN=true
+DOWNLOAD_FEDORA=true
+DOWNLOAD_RASPI=true
+CHECK_ONLY=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --debian-only)
+            DOWNLOAD_FEDORA=false
+            DOWNLOAD_RASPI=false
+            shift
+            ;;
+        --fedora-only)
+            DOWNLOAD_DEBIAN=false
+            DOWNLOAD_RASPI=false
+            shift
+            ;;
+        --raspi-only)
+            DOWNLOAD_DEBIAN=false
+            DOWNLOAD_FEDORA=false
+            shift
+            ;;
+        --check)
+            CHECK_ONLY=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+mkdir -p "$ISOS_DIR"
+
+discover_filename() {
+    local dir_url="$1"
+    local pattern="$2"
+    local filename
+    filename=$(curl -sfL "$dir_url" | grep -oP "$pattern" | sort -V | tail -1)
+    if [[ -z "$filename" ]]; then
+        echo "Error: Could not find file matching '$pattern' at $dir_url" >&2
+        return 1
+    fi
+    echo "$filename"
+}
+
+download_image() {
+    local dir_url="$1"
+    local filename="$2"
+    local url="${dir_url}${filename}"
+    local dest="$ISOS_DIR/$filename"
+
+    if [[ "$CHECK_ONLY" == "true" ]]; then
+        if [[ -f "$dest" ]]; then
+            echo "  EXISTS: $filename ($(du -h "$dest" | cut -f1))"
+        else
+            echo "  DOWNLOAD: $url"
+        fi
+        return
+    fi
+
+    if [[ -f "$dest" ]]; then
+        local size
+        size=$(stat --format=%s "$dest" 2>/dev/null || stat -f%z "$dest" 2>/dev/null)
+        if [[ "$size" -ge "$MIN_IMAGE_BYTES" ]]; then
+            echo "Already downloaded: $filename ($(du -h "$dest" | cut -f1))"
+            return
+        fi
+        echo "Existing file too small ($(du -h "$dest" | cut -f1)), re-downloading..."
+        rm -f "$dest"
+    fi
+
+    echo "Downloading: $url"
+    echo "Destination: $dest"
+    curl -L --fail -o "$dest.partial" --progress-bar "$url"
+
+    # Verify the download is a real image, not an HTML error page
+    local size
+    size=$(stat --format=%s "$dest.partial" 2>/dev/null || stat -f%z "$dest.partial" 2>/dev/null)
+    if [[ "$size" -lt "$MIN_IMAGE_BYTES" ]]; then
+        echo "Error: Downloaded file is only $(du -h "$dest.partial" | cut -f1) — expected an image." >&2
+        echo "The URL may be incorrect or the mirror returned an error page." >&2
+        rm -f "$dest.partial"
+        return 1
+    fi
+
+    mv "$dest.partial" "$dest"
+    echo "Downloaded: $filename ($(du -h "$dest" | cut -f1))"
+}
+
+echo "=== Image Downloads ==="
+echo "Directory: $ISOS_DIR"
+echo ""
+
+if [[ "$DOWNLOAD_DEBIAN" == "true" ]]; then
+    echo "Debian (stable):"
+    debian_iso=$(discover_filename "$DEBIAN_DIR_URL" "$DEBIAN_ISO_PATTERN")
+    echo "  Found: $debian_iso"
+    download_image "$DEBIAN_DIR_URL" "$debian_iso"
+    echo ""
+fi
+
+if [[ "$DOWNLOAD_FEDORA" == "true" ]]; then
+    echo "Fedora ${FEDORA_RELEASE} Server:"
+    fedora_iso=$(discover_filename "$FEDORA_DIR_URL" "$FEDORA_ISO_PATTERN")
+    echo "  Found: $fedora_iso"
+    download_image "$FEDORA_DIR_URL" "$fedora_iso"
+    echo ""
+fi
+
+if [[ "$DOWNLOAD_RASPI" == "true" ]]; then
+    echo "Raspberry Pi OS Lite (arm64):"
+    raspi_subdir=$(discover_filename "$RASPI_IMAGES_URL" "$RASPI_SUBDIR_PATTERN")
+    raspi_dir_url="${RASPI_IMAGES_URL}${raspi_subdir}/"
+    raspi_image=$(discover_filename "$raspi_dir_url" "$RASPI_IMAGE_PATTERN")
+    echo "  Found: $raspi_image"
+    download_image "$raspi_dir_url" "$raspi_image"
+    echo ""
+fi
+
+if [[ "$CHECK_ONLY" != "true" ]]; then
+    echo "=== Done ==="
+    echo "Images saved to: $ISOS_DIR"
+    ls -lh "$ISOS_DIR"/ 2>/dev/null || true
+fi

--- a/_scripts/workstation-usb-image
+++ b/_scripts/workstation-usb-image
@@ -1,0 +1,509 @@
+#!/bin/bash
+## Build a raw disk image for the NixOS workstation USB
+## Uses loop devices instead of QEMU to avoid build VM issues.
+set -eo pipefail
+
+BIN=$(dirname $(realpath ${BASH_SOURCE}))
+ROOT_DIR=$(dirname ${BIN})
+
+## Use /scratch if available (default /tmp may be a small tmpfs):
+if [[ -d /scratch ]]; then
+    export TMPDIR=/scratch/tmp
+    export XDG_CACHE_HOME=/scratch/cache
+    mkdir -p "$TMPDIR" "$XDG_CACHE_HOME"
+fi
+
+source ${BIN}/funcs.sh
+source ${BIN}/workstation-build-lib.sh
+
+IMAGE_DIR="${ROOT_DIR}/_archive"
+IMAGE_FILE=""
+IMAGE_SIZE=""
+BASE_ONLY=""
+FROM_BASE=""
+DRY_RUN=""
+ARCHIVE_SOURCE="${ROOT_DIR}/_archive"
+MANIFEST_FILE=""
+
+usage() {
+    echo "Usage: d.rymcg.tech workstation-usb-image [OPTIONS]"
+    echo ""
+    echo "Build a raw NixOS disk image for the workstation USB."
+    echo "The image can be written to a USB drive with dd."
+    echo "Requires sudo for loop device and mount operations."
+    echo ""
+    echo "By default, the image includes all archive data (Docker images,"
+    echo "ISOs, Docker CE packages) found in _archive/. The image size is"
+    echo "auto-calculated to fit everything plus headroom."
+    echo ""
+    echo "Options:"
+    echo "  --size SIZE        Override auto-calculated image size (e.g. 128G)"
+    echo "  --output FILE      Output path (default: _archive/workstation-usb.img,"
+    echo "                     or _archive/workstation-usb-base.img with --base-only)"
+    echo "  --base-only        Build OS only, without archive data (smaller image)"
+    echo "  --from-base [PATH] Reuse a base image instead of rebuilding from scratch."
+    echo "                     Copies the base, expands it, and adds archive data."
+    echo "                     Default path: _archive/workstation-usb-base.img"
+    echo "  --dry-run          Build the system closure only, don't create image"
+    echo "  -h, --help         Show this help"
+    echo ""
+    echo "After building, test in a VM or write to USB:"
+    echo "  d.rymcg.tech workstation-usb-test-vm"
+    echo "  sudo dd if=${IMAGE_FILE} of=/dev/sdX bs=4M status=progress conv=fsync"
+    echo ""
+    echo "The root partition auto-expands to fill the USB on first boot."
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --size)
+            IMAGE_SIZE="$2"
+            shift 2
+            ;;
+        --output)
+            IMAGE_FILE="$2"
+            shift 2
+            ;;
+        --base-only)
+            BASE_ONLY=1
+            shift
+            ;;
+        --from-base)
+            if [[ -n "${2:-}" ]] && [[ "${2}" != --* ]]; then
+                FROM_BASE="$2"
+                shift 2
+            else
+                FROM_BASE="${IMAGE_DIR}/workstation-usb-base.img"
+                shift
+            fi
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Apply default output path based on mode
+if [[ -z "$IMAGE_FILE" ]]; then
+    if [[ -n "$BASE_ONLY" ]]; then
+        IMAGE_FILE="${IMAGE_DIR}/workstation-usb-base.img"
+    else
+        IMAGE_FILE="${IMAGE_DIR}/workstation-usb.img"
+    fi
+fi
+
+# Validate --from-base path
+if [[ -n "$FROM_BASE" ]]; then
+    if [[ ! -f "$FROM_BASE" ]]; then
+        echo "Error: base image not found: $FROM_BASE" >&2
+        exit 1
+    fi
+    if [[ -n "$BASE_ONLY" ]]; then
+        echo "Error: --from-base and --base-only cannot be used together" >&2
+        exit 1
+    fi
+fi
+
+# Auto-detect base image for full builds (no --base-only, no --from-base)
+DEFAULT_BASE="${IMAGE_DIR}/workstation-usb-base.img"
+if [[ -z "$BASE_ONLY" ]] && [[ -z "$FROM_BASE" ]] && [[ -f "$DEFAULT_BASE" ]]; then
+    BASE_SIZE_HUMAN=$(du -h --apparent-size "$DEFAULT_BASE" | cut -f1)
+    echo "Base image found: $DEFAULT_BASE ($BASE_SIZE_HUMAN)"
+    if confirm yes "Use it to skip the nix build" "?"; then
+        FROM_BASE="$DEFAULT_BASE"
+    fi
+    echo ""
+fi
+
+if [[ -z "$BASE_ONLY" ]]; then
+    workstation_archive_preflight
+    workstation_archive_select
+else
+    # --base-only: empty manifest (no archive data, but still run chroot tasks)
+    SELECTED_IMAGE_PROJECTS=()
+    COMFYUI_SELECTED_FILES=()
+    INCLUDE_ISOS=false
+    INCLUDE_DOCKER_PACKAGES=false
+    MANIFEST_FILE=$(mktemp)
+    {
+        echo "ARCHIVE_ROOT=\"${ARCHIVE_SOURCE}\""
+        echo "IMAGE_PROJECTS=\"\""
+        echo "COMFYUI_FILES=\"\""
+        echo "INCLUDE_ISOS=false"
+        echo "INCLUDE_DOCKER_PACKAGES=false"
+    } > "$MANIFEST_FILE"
+fi
+
+if [[ -z "$FROM_BASE" ]]; then
+    workstation_configure_settings
+fi
+
+echo "=== Build summary ==="
+echo "Output: $IMAGE_FILE"
+if [[ -n "$FROM_BASE" ]]; then
+    echo "Mode: from-base (reusing $FROM_BASE + archive data)"
+elif [[ -n "$BASE_ONLY" ]]; then
+    echo "Mode: base only (OS without archive data)"
+else
+    echo "Mode: full (OS + archive data)"
+fi
+if [[ -n "$IMAGE_SIZE" ]]; then
+    echo "Size: $IMAGE_SIZE (manual override)"
+elif [[ -n "$FROM_BASE" ]]; then
+    # from-base: estimate = base logical size + archive + headroom
+    _base_bytes=$(stat -c%s "$FROM_BASE")
+    _base_gb=$(awk "BEGIN {printf \"%.1f\", $_base_bytes / 1073741824}")
+    echo "Base image: ${_base_gb} GB"
+    ESTIMATE_BYTES=$_base_bytes
+    if [[ -z "$BASE_ONLY" ]]; then
+        for proj in "${SELECTED_IMAGE_PROJECTS[@]}"; do
+            proj_dir="$ARCHIVE_IMG_DIR/$proj"
+            [[ -d "$proj_dir" ]] && ESTIMATE_BYTES=$((ESTIMATE_BYTES + $(du -sbL "$proj_dir" | cut -f1)))
+        done
+        for f in "${COMFYUI_SELECTED_FILES[@]}"; do
+            [[ -f "$ARCHIVE_IMG_DIR/comfyui/$f" ]] && ESTIMATE_BYTES=$((ESTIMATE_BYTES + $(stat -c%s "$ARCHIVE_IMG_DIR/comfyui/$f")))
+        done
+        if ${INCLUDE_ISOS:-false} && [[ -d "${ISOS_DIR:-}" ]]; then
+            ESTIMATE_BYTES=$((ESTIMATE_BYTES + $(du -sbL "$ISOS_DIR" | cut -f1)))
+        fi
+        if ${INCLUDE_DOCKER_PACKAGES:-false} && [[ -d "${DOCKER_PKG_DIR:-}" ]]; then
+            ESTIMATE_BYTES=$((ESTIMATE_BYTES + $(du -sbL "$DOCKER_PKG_DIR" | cut -f1)))
+        fi
+    fi
+    # Headroom: 25% of archive data or 2GB minimum (base already has OS headroom)
+    _archive_est=$((ESTIMATE_BYTES - _base_bytes))
+    HEADROOM=$((_archive_est * 25 / 100))
+    [[ $HEADROOM -lt $((2 * 1073741824)) ]] && HEADROOM=$((2 * 1073741824))
+    ESTIMATE_BYTES=$((ESTIMATE_BYTES + HEADROOM))
+    ESTIMATE_GB=$(( (ESTIMATE_BYTES + 1073741823) / 1073741824 ))
+    echo "Size: ~${ESTIMATE_GB} GB (estimated)"
+else
+    # Estimate image size before building (closure ~10GB + archive data + headroom)
+    ESTIMATE_BYTES=$((10 * 1073741824))  # ~10 GB base closure estimate
+    if [[ -z "$BASE_ONLY" ]]; then
+        for proj in "${SELECTED_IMAGE_PROJECTS[@]}"; do
+            proj_dir="$ARCHIVE_IMG_DIR/$proj"
+            [[ -d "$proj_dir" ]] && ESTIMATE_BYTES=$((ESTIMATE_BYTES + $(du -sbL "$proj_dir" | cut -f1)))
+        done
+        for f in "${COMFYUI_SELECTED_FILES[@]}"; do
+            [[ -f "$ARCHIVE_IMG_DIR/comfyui/$f" ]] && ESTIMATE_BYTES=$((ESTIMATE_BYTES + $(stat -c%s "$ARCHIVE_IMG_DIR/comfyui/$f")))
+        done
+        if ${INCLUDE_ISOS:-false} && [[ -d "${ISOS_DIR:-}" ]]; then
+            ESTIMATE_BYTES=$((ESTIMATE_BYTES + $(du -sbL "$ISOS_DIR" | cut -f1)))
+        fi
+        if ${INCLUDE_DOCKER_PACKAGES:-false} && [[ -d "${DOCKER_PKG_DIR:-}" ]]; then
+            ESTIMATE_BYTES=$((ESTIMATE_BYTES + $(du -sbL "$DOCKER_PKG_DIR" | cut -f1)))
+        fi
+    fi
+    # Add 1GB ESP + 25% headroom (or 8GB min)
+    HEADROOM=$((ESTIMATE_BYTES * 25 / 100))
+    [[ $HEADROOM -lt $((8 * 1073741824)) ]] && HEADROOM=$((8 * 1073741824))
+    ESTIMATE_BYTES=$((ESTIMATE_BYTES + HEADROOM + 1073741824))
+    ESTIMATE_GB=$(( (ESTIMATE_BYTES + 1073741823) / 1073741824 ))
+    echo "Size: ~${ESTIMATE_GB} GB (estimated, exact size calculated after build)"
+fi
+echo ""
+confirm yes "Build the image" "?" || exit 0
+
+# Acquire sudo early so the credential is cached for the disk image step later
+sudo true
+
+if [[ -z "$FROM_BASE" ]]; then
+    echo ""
+    workstation_create_bare_repos
+
+    echo ""
+    echo "=== Building NixOS system closure ==="
+    SYSTEM_PATH=$(workstation_nix_build "nixosConfigurations.workstation.config.system.build.toplevel")
+    echo "System closure: $SYSTEM_PATH"
+
+    # Resolve nixos-install path from the system closure's dependencies
+    NIXOS_INSTALL=$(workstation_nix_build "nixosConfigurations.workstation.config.system.build.nixos-install")/bin/nixos-install
+    if [[ ! -x "$NIXOS_INSTALL" ]]; then
+        echo "Error: nixos-install not found at $NIXOS_INSTALL" >&2
+        exit 1
+    fi
+    echo "nixos-install: $NIXOS_INSTALL"
+
+    # Now that nix has read settings.nix, hide it from git status
+    workstation_hide_settings
+fi
+
+# Calculate sizes
+echo ""
+echo "=== Calculating image size ==="
+
+ARCHIVE_BYTES=0
+
+if [[ -n "$FROM_BASE" ]]; then
+    # from-base: use base image logical size instead of closure
+    BASE_SIZE=$(stat -c%s "$FROM_BASE")
+    BASE_GB=$(awk "BEGIN {printf \"%.1f\", $BASE_SIZE / 1073741824}")
+    echo "Base image: ${BASE_GB} GB"
+else
+    # Get closure size in bytes
+    CLOSURE_BYTES=$(nix path-info -S "$SYSTEM_PATH" | awk '{print $2}')
+    CLOSURE_GB=$(awk "BEGIN {printf \"%.1f\", $CLOSURE_BYTES / 1073741824}")
+    echo "NixOS closure: ${CLOSURE_GB} GB"
+fi
+
+if [[ -z "$BASE_ONLY" ]]; then
+    _img_bytes=0
+    for proj in "${SELECTED_IMAGE_PROJECTS[@]}"; do
+        proj_dir="$ARCHIVE_IMG_DIR/$proj"
+        [[ -d "$proj_dir" ]] && _img_bytes=$((_img_bytes + $(du -sbL "$proj_dir" | cut -f1)))
+    done
+    for f in "${COMFYUI_SELECTED_FILES[@]}"; do
+        [[ -f "$ARCHIVE_IMG_DIR/comfyui/$f" ]] && _img_bytes=$((_img_bytes + $(stat -c%s "$ARCHIVE_IMG_DIR/comfyui/$f")))
+    done
+    if [[ $_img_bytes -gt 0 ]]; then
+        _img_gb=$(awk "BEGIN {printf \"%.1f\", $_img_bytes / 1073741824}")
+        echo "Docker images: ${_img_gb} GB"
+        ARCHIVE_BYTES=$((ARCHIVE_BYTES + _img_bytes))
+    else
+        echo "Docker images: (none selected)"
+    fi
+
+    if ${INCLUDE_ISOS:-false} && [[ -d "${ISOS_DIR:-}" ]] && [[ -n "$(ls -A "$ISOS_DIR" 2>/dev/null)" ]]; then
+        dir_bytes=$(du -sbL "$ISOS_DIR" | cut -f1)
+        dir_gb=$(awk "BEGIN {printf \"%.1f\", $dir_bytes / 1073741824}")
+        echo "ISOs: ${dir_gb} GB"
+        ARCHIVE_BYTES=$((ARCHIVE_BYTES + dir_bytes))
+    fi
+
+    if ${INCLUDE_DOCKER_PACKAGES:-false} && [[ -d "${DOCKER_PKG_DIR:-}" ]] && [[ -n "$(ls -A "$DOCKER_PKG_DIR" 2>/dev/null)" ]]; then
+        dir_bytes=$(du -sbL "$DOCKER_PKG_DIR" | cut -f1)
+        dir_gb=$(awk "BEGIN {printf \"%.1f\", $dir_bytes / 1073741824}")
+        echo "Docker CE packages: ${dir_gb} GB"
+        ARCHIVE_BYTES=$((ARCHIVE_BYTES + dir_bytes))
+    fi
+fi
+
+# Auto-calculate image size if not specified
+if [[ -z "$IMAGE_SIZE" ]]; then
+    if [[ -n "$FROM_BASE" ]]; then
+        # from-base: image = base + archive + headroom
+        # Headroom: 25% of archive data or 2GB minimum (base already has OS headroom)
+        HEADROOM_BYTES=$((ARCHIVE_BYTES * 25 / 100))
+        [[ $HEADROOM_BYTES -lt $((2 * 1073741824)) ]] && HEADROOM_BYTES=$((2 * 1073741824))
+        IMAGE_BYTES=$((BASE_SIZE + ARCHIVE_BYTES + HEADROOM_BYTES))
+    else
+        # Total = closure + archive + 1GB ESP + headroom
+        # Headroom covers: ext4/nix overhead, chroot tasks (emacs packages,
+        # Rust toolchain), and general breathing room.
+        TOTAL_BYTES=$((CLOSURE_BYTES + ARCHIVE_BYTES))
+        # Add 1GB for ESP + 8GB headroom (or 20% of total, whichever is larger)
+        HEADROOM_BYTES=$((8 * 1073741824))
+        PCT_HEADROOM=$((TOTAL_BYTES * 25 / 100))
+        if [[ $PCT_HEADROOM -gt $HEADROOM_BYTES ]]; then
+            HEADROOM_BYTES=$PCT_HEADROOM
+        fi
+        ESP_BYTES=$((1 * 1073741824))
+        IMAGE_BYTES=$((TOTAL_BYTES + HEADROOM_BYTES + ESP_BYTES))
+    fi
+    # Round up to nearest GB
+    IMAGE_GB=$(( (IMAGE_BYTES + 1073741823) / 1073741824 ))
+    IMAGE_SIZE="${IMAGE_GB}G"
+fi
+
+echo ""
+echo "Image size: $IMAGE_SIZE"
+
+if [[ -n "$DRY_RUN" ]]; then
+    echo ""
+    echo "(dry run — system closure built, image not created)"
+    exit 0
+fi
+
+echo ""
+echo "=== Creating disk image ==="
+echo "Image: ${IMAGE_FILE} (${IMAGE_SIZE})"
+if [[ -n "$FROM_BASE" ]]; then
+    echo "Mode: from-base (reusing $FROM_BASE + archive data)"
+elif [[ -z "$BASE_ONLY" ]]; then
+    echo "Mode: full (includes archive data)"
+else
+    echo "Mode: base only (OS without archive data)"
+fi
+echo "This requires sudo for loop devices and mounting."
+echo ""
+
+mkdir -p "$(dirname "$IMAGE_FILE")"
+
+POST_INSTALL_SCRIPT="${ROOT_DIR}/nix/workstation/installer/post-install.sh"
+
+# The rest runs as root (pass values as positional args to avoid sudo env_reset)
+exec sudo bash -c '
+set -euo pipefail
+IMAGE_FILE="$1"
+IMAGE_SIZE="$2"
+SYSTEM_PATH="$3"
+NIXOS_INSTALL="$4"
+export PATH="$5:$PATH"
+BASE_ONLY="${6:-}"
+POST_INSTALL_SCRIPT="$7"
+MANIFEST_FILE="${8:-}"
+FROM_BASE="${9:-}"
+
+MOUNT=$(mktemp -d)
+LOOP=""
+
+cleanup() {
+    set +e
+    if [[ -n "$MOUNT" ]]; then
+        fuser -km "$MOUNT" 2>/dev/null || true
+        sleep 1
+        umount -lR "$MOUNT" 2>/dev/null || true
+        rmdir "$MOUNT" 2>/dev/null
+    fi
+    if [[ -n "$LOOP" ]]; then
+        losetup -d "$LOOP" 2>/dev/null
+    fi
+    if [[ -n "${MANIFEST_FILE:-}" ]] && [[ "$MANIFEST_FILE" == /tmp/* ]]; then
+        rm -f "$MANIFEST_FILE" 2>/dev/null
+    fi
+}
+trap cleanup EXIT
+
+# Clean up stale loop devices from previous interrupted builds
+STALE_LOOPS=$(losetup -l -n -O NAME,BACK-FILE 2>/dev/null | grep "workstation-usb" | awk "{print \$1}" || true)
+if [[ -n "$STALE_LOOPS" ]]; then
+    echo "Cleaning up stale loop devices from previous builds..."
+    for stale in $STALE_LOOPS; do
+        fuser -km "${stale}p2" 2>/dev/null || true
+        fuser -km "${stale}p1" 2>/dev/null || true
+    done
+    sleep 1
+    for stale in $STALE_LOOPS; do
+        umount -l "${stale}p1" 2>/dev/null || true
+        umount -l "${stale}p2" 2>/dev/null || true
+        losetup -d "$stale" 2>/dev/null || true
+    done
+    echo "Cleaned up $(echo "$STALE_LOOPS" | wc -w) stale loop device(s)"
+fi
+
+if [[ -n "$FROM_BASE" ]]; then
+    # === From-base flow: copy base image, expand, add archive data ===
+    echo "=== Copying base image ==="
+    cp --sparse=always "$FROM_BASE" "$IMAGE_FILE"
+
+    # Extend sparse file to the target size
+    truncate -s "$IMAGE_SIZE" "$IMAGE_FILE"
+
+    # Set up loop device
+    LOOP=$(losetup --find --show --partscan "$IMAGE_FILE")
+    echo "Loop device: $LOOP"
+
+    # Relocate backup GPT header to end of expanded image
+    sgdisk -e "$LOOP"
+
+    # Expand partition 2 to fill remaining space
+    sgdisk -d 2 -n 2:0:0 -t 2:8300 -c 2:nixos "$LOOP"
+    partprobe "$LOOP" || true
+    sleep 1
+
+    # Mount btrfs root
+    mount -o compress=zstd,noatime "${LOOP}p2" "$MOUNT"
+
+    # Grow the btrfs filesystem to fill the expanded partition
+    btrfs filesystem resize max "$MOUNT"
+
+    # Mount ESP
+    mkdir -p "$MOUNT/boot"
+    mount -o umask=0077 "${LOOP}p1" "$MOUNT/boot"
+
+    # Run post-install in archive-only mode (no chroot tasks)
+    if [[ -x "$POST_INSTALL_SCRIPT" ]]; then
+        echo ""
+        echo "=== Running post-install (archive data only, skipping chroot tasks) ==="
+        "$POST_INSTALL_SCRIPT" "$MOUNT" "$MANIFEST_FILE" --archive-only
+    fi
+else
+    # === Normal flow: create image from scratch ===
+
+    # Create sparse image file
+    truncate -s "$IMAGE_SIZE" "$IMAGE_FILE"
+
+    # Set up loop device
+    LOOP=$(losetup --find --show --partscan "$IMAGE_FILE")
+    echo "Loop device: $LOOP"
+
+    # Partition: 1GB ESP + rest btrfs
+    sgdisk --zap-all "$LOOP"
+    sgdisk -n 1:0:+1G -t 1:ef00 -c 1:ESP "$LOOP"
+    sgdisk -n 2:0:0 -t 2:8300 -c 2:nixos "$LOOP"
+    partprobe "$LOOP" || true
+    sleep 1
+
+    # Format
+    mkfs.fat -F32 -n ESP "${LOOP}p1"
+    mkfs.btrfs -L nixos -f "${LOOP}p2"
+
+    # Mount
+    mount -o compress=zstd,noatime "${LOOP}p2" "$MOUNT"
+    mkdir -p "$MOUNT/boot"
+    mount -o umask=0077 "${LOOP}p1" "$MOUNT/boot"
+
+    # Install NixOS
+    echo "=== Installing NixOS into image ==="
+    "$NIXOS_INSTALL" --system "$SYSTEM_PATH" --root "$MOUNT" --no-root-password --no-channel-copy
+
+    # Run post-install tasks
+    if [[ -x "$POST_INSTALL_SCRIPT" ]]; then
+        echo ""
+        if [[ -z "$BASE_ONLY" ]]; then
+            echo "=== Running post-install (archive data + chroot tasks) ==="
+        else
+            echo "=== Running post-install (chroot tasks, no archive data) ==="
+        fi
+        "$POST_INSTALL_SCRIPT" "$MOUNT" "$MANIFEST_FILE"
+    fi
+fi
+
+# Sync all pending writes before unmounting
+sync
+
+# Unmount
+umount "$MOUNT/boot" 2>/dev/null || true
+umount "$MOUNT" 2>/dev/null || true
+if mountpoint -q "$MOUNT" 2>/dev/null; then
+    echo "Warning: mount point still busy, waiting..."
+    sleep 3
+    sync
+    umount -R "$MOUNT" 2>/dev/null || umount -lR "$MOUNT" 2>/dev/null || true
+    sleep 2
+    sync
+fi
+rmdir "$MOUNT" 2>/dev/null || true
+MOUNT=""
+
+# Detach loop
+sync
+losetup -d "$LOOP"
+LOOP=""
+
+echo ""
+echo "=== Generating SHA-256 checksum ==="
+sha256sum "$IMAGE_FILE" > "${IMAGE_FILE}.sha256"
+echo "Checksum: ${IMAGE_FILE}.sha256"
+
+echo ""
+echo "=== Image built successfully ==="
+echo "Image: $IMAGE_FILE ($(du -h --apparent-size "$IMAGE_FILE" | cut -f1))"
+echo "SHA-256: $(cat "${IMAGE_FILE}.sha256")"
+echo ""
+echo "Write to USB with:"
+echo "  sudo dd if=$IMAGE_FILE of=/dev/sdX bs=4M status=progress conv=fsync"
+echo ""
+echo "The root partition auto-expands to fill the USB on first boot."
+' _ "$IMAGE_FILE" "$IMAGE_SIZE" "${SYSTEM_PATH:-}" "${NIXOS_INSTALL:-}" "$PATH" "${BASE_ONLY:-}" "$POST_INSTALL_SCRIPT" "${MANIFEST_FILE:-}" "${FROM_BASE:-}"

--- a/_scripts/workstation-usb-install
+++ b/_scripts/workstation-usb-install
@@ -1,0 +1,63 @@
+#!/bin/bash
+## Direct install NixOS workstation to a USB device
+set -eo pipefail
+
+BIN=$(dirname $(realpath ${BASH_SOURCE}))
+ROOT_DIR=$(dirname ${BIN})
+source ${BIN}/funcs.sh
+
+usage() {
+    echo "Usage: d.rymcg.tech workstation-usb-install [OPTIONS] /dev/sdX"
+    echo ""
+    echo "Install the NixOS workstation directly to a USB device."
+    echo "This will partition, format, and install NixOS, then copy archive data."
+    echo ""
+    echo "WARNING: This will ERASE ALL DATA on the target device."
+    echo ""
+    echo "Options:"
+    echo "  --base-only  Install OS only, without archive data"
+    echo "  -h, --help   Show this help"
+}
+
+DEVICE=""
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --base-only)
+            EXTRA_ARGS+=("--base-only")
+            shift
+            ;;
+        -*)
+            echo "Error: unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+        *)
+            if [[ -z "$DEVICE" ]]; then
+                DEVICE="$1"
+            else
+                echo "Error: unexpected argument: $1" >&2
+                usage >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$DEVICE" ]]; then
+    echo "Error: No device specified." >&2
+    usage >&2
+    exit 1
+fi
+
+if [[ $EUID -ne 0 ]]; then
+    exec sudo bash -c "export PATH=\"$PATH:\$PATH\"; exec \"$ROOT_DIR/nix/workstation/installer/install-to-device.sh\" ${EXTRA_ARGS[*]:+${EXTRA_ARGS[*]}} \"$DEVICE\""
+fi
+
+exec "${ROOT_DIR}/nix/workstation/installer/install-to-device.sh" "${EXTRA_ARGS[@]}" "$DEVICE"

--- a/_scripts/workstation-usb-post-install
+++ b/_scripts/workstation-usb-post-install
@@ -1,0 +1,53 @@
+#!/bin/bash
+## Copy archive data to a mounted NixOS workstation USB
+set -eo pipefail
+
+BIN=$(dirname $(realpath ${BASH_SOURCE}))
+ROOT_DIR=$(dirname ${BIN})
+source ${BIN}/funcs.sh
+
+usage() {
+    echo "Usage: d.rymcg.tech workstation-usb-post-install /mnt"
+    echo ""
+    echo "Copy Docker image archive, ISOs, and Docker CE packages"
+    echo "into a mounted NixOS workstation USB's nix store."
+    echo ""
+    echo "The USB's root filesystem must be mounted at the given path."
+    echo "Archive data is read from: ${ROOT_DIR}/_archive/"
+    echo ""
+    echo "Options:"
+    echo "  -h, --help   Show this help"
+}
+
+MOUNT=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            if [[ -z "$MOUNT" ]]; then
+                MOUNT="$1"
+            else
+                echo "Error: unexpected argument: $1" >&2
+                usage >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$MOUNT" ]]; then
+    echo "Error: No mount path specified." >&2
+    usage >&2
+    exit 1
+fi
+
+if [[ $EUID -ne 0 ]]; then
+    exec sudo bash -c "export PATH=\"$PATH:\$PATH\"; exec \"$ROOT_DIR/nix/workstation/installer/post-install.sh\" \"$MOUNT\""
+fi
+
+exec "${ROOT_DIR}/nix/workstation/installer/post-install.sh" "$MOUNT"

--- a/_scripts/workstation-usb-test-vm
+++ b/_scripts/workstation-usb-test-vm
@@ -1,0 +1,287 @@
+#!/bin/bash
+## Launch a QEMU test VM from a workstation USB disk image.
+## Creates a CoW (copy-on-write) overlay so the original image is never modified.
+set -eo pipefail
+
+BIN=$(dirname $(realpath ${BASH_SOURCE}))
+ROOT_DIR=$(dirname ${BIN})
+source ${BIN}/funcs.sh
+
+IMAGE_FILE=""
+BASE_MODE=""
+MEMORY="${MEMORY:-4096}"
+CPUS="${CPUS:-$(nproc)}"
+SSH_PORT="${SSH_PORT:-10022}"
+DISPLAY_TYPE=""
+NO_NETWORK=""
+DISK_SIZE=""
+CLEAN=""
+EJECT=""
+
+usage() {
+    echo "Usage: d.rymcg.tech workstation-usb-test-vm [OPTIONS]"
+    echo ""
+    echo "Launch a QEMU test VM from a workstation USB disk image."
+    echo "Creates a temporary CoW (copy-on-write) overlay so the original"
+    echo "image is never modified. Changes are discarded when the VM exits."
+    echo ""
+    echo "Options:"
+    echo "  --image FILE    Disk image path (default: auto-detected)"
+    echo "  --base          Use the base-only image (workstation-usb-base.img)"
+    echo "  --memory MB     RAM in MB (default: $MEMORY, or set MEMORY env var)"
+    echo "  --cpus N        Number of CPUs (default: all cores)"
+    echo "  --ssh-port PORT Host SSH port forwarding (default: $SSH_PORT)"
+    echo "  --disk GB       Attach a persistent virtual disk as /dev/vda (created if needed)"
+    echo "  --eject         Boot only from the persistent disk (no USB image attached)"
+    echo "  --clean         Delete the persistent virtual disk and exit"
+    echo "  --no-network    Disable networking (simulate air-gapped environment)"
+    echo "  --display TYPE  QEMU display: gtk, sdl, none (default: gtk)"
+    echo "  -h, --help      Show this help"
+    echo ""
+    echo "Environment variables:"
+    echo "  MEMORY       RAM in MB (default: 4096)"
+    echo "  CPUS         Number of CPUs (default: all cores)"
+    echo "  SSH_PORT     Host SSH port (default: 10022)"
+    echo ""
+    echo "Connect via SSH while the VM is running:"
+    echo "  ssh -o StrictHostKeyChecking=no -p $SSH_PORT user@localhost"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --image)
+            IMAGE_FILE="$2"
+            shift 2
+            ;;
+        --base)
+            BASE_MODE=1
+            shift
+            ;;
+        --memory)
+            MEMORY="$2"
+            shift 2
+            ;;
+        --cpus)
+            CPUS="$2"
+            shift 2
+            ;;
+        --ssh-port)
+            SSH_PORT="$2"
+            shift 2
+            ;;
+        --disk)
+            DISK_SIZE="$2"
+            shift 2
+            ;;
+        --eject)
+            EJECT=1
+            shift
+            ;;
+        --clean)
+            CLEAN=1
+            shift
+            ;;
+        --no-network)
+            NO_NETWORK=1
+            shift
+            ;;
+        --display)
+            DISPLAY_TYPE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Default image path
+if [[ -z "$IMAGE_FILE" ]]; then
+    if [[ -n "$BASE_MODE" ]]; then
+        IMAGE_FILE="${ROOT_DIR}/_archive/workstation-usb-base.img"
+    else
+        IMAGE_FILE="${ROOT_DIR}/_archive/workstation-usb.img"
+    fi
+fi
+
+# Default display
+if [[ -z "$DISPLAY_TYPE" ]]; then
+    if [[ -n "${DISPLAY:-}" ]]; then
+        DISPLAY_TYPE="gtk"
+    else
+        DISPLAY_TYPE="none"
+    fi
+fi
+
+if [[ ! -f "$IMAGE_FILE" ]]; then
+    echo "Error: Image not found: $IMAGE_FILE" >&2
+    if [[ -n "$BASE_MODE" ]]; then
+        echo "Build it first with: d.rymcg.tech workstation-usb-image --base-only" >&2
+    else
+        echo "Build it first with: d.rymcg.tech workstation-usb-image" >&2
+    fi
+    exit 1
+fi
+
+# Find OVMF firmware (needed for UEFI boot)
+OVMF_CODE=""
+OVMF_VARS=""
+for prefix in \
+    /run/current-system/sw/share/OVMF \
+    /usr/share/OVMF \
+    /usr/share/edk2/x64 \
+    /usr/share/edk2-ovmf/x64 \
+    /usr/share/qemu; do
+    if [[ -f "$prefix/OVMF_CODE.fd" ]] && [[ -f "$prefix/OVMF_VARS.fd" ]]; then
+        OVMF_CODE="$prefix/OVMF_CODE.fd"
+        OVMF_VARS="$prefix/OVMF_VARS.fd"
+        break
+    fi
+done
+
+if [[ -z "$OVMF_CODE" ]]; then
+    echo "Error: OVMF firmware not found (OVMF_CODE.fd / OVMF_VARS.fd)." >&2
+    echo "Install OVMF/edk2 for UEFI boot support." >&2
+    exit 1
+fi
+
+# Check for KVM support
+KVM_FLAG=""
+if [[ -w /dev/kvm ]]; then
+    KVM_FLAG="-enable-kvm"
+else
+    echo "Warning: /dev/kvm not accessible, running without hardware acceleration (slow)." >&2
+fi
+
+# Create temporary CoW overlay
+OVERLAY=$(mktemp --suffix=.qcow2)
+
+DISK_FILE="${ROOT_DIR}/_archive/workstation-usb-test-disk.qcow2"
+
+# Handle --clean: delete persistent disk and exit
+if [[ -n "$CLEAN" ]]; then
+    if [[ -f "$DISK_FILE" ]]; then
+        rm -f "$DISK_FILE"
+        echo "Deleted persistent disk: $DISK_FILE"
+    else
+        echo "No persistent disk found."
+    fi
+    exit 0
+fi
+
+if [[ -n "$EJECT" ]] && [[ -z "$DISK_SIZE" ]]; then
+    if [[ ! -f "$DISK_FILE" ]]; then
+        echo "Error: --eject requires a persistent disk. Use --disk GB first." >&2
+        exit 1
+    fi
+fi
+
+if [[ -n "$DISK_SIZE" ]]; then
+    if [[ -f "$DISK_FILE" ]]; then
+        echo "Using existing persistent disk: $DISK_FILE"
+    else
+        echo "Creating ${DISK_SIZE}G persistent disk: $DISK_FILE"
+        qemu-img create -f qcow2 "$DISK_FILE" "${DISK_SIZE}G" >/dev/null
+    fi
+fi
+
+# Always use fresh NVRAM so UEFI rescans boot entries each start.
+# QEMU bootindex hints determine priority (persistent disk before USB).
+NVRAM=$(mktemp --suffix=_OVMF_VARS.fd)
+cp "$OVMF_VARS" "$NVRAM"
+
+cleanup() {
+    rm -f "$OVERLAY" "$NVRAM"
+}
+trap cleanup EXIT
+
+if [[ -z "$EJECT" ]]; then
+    echo "Creating CoW overlay on $(basename "$IMAGE_FILE")..."
+    qemu-img create -f qcow2 -b "$(realpath "$IMAGE_FILE")" -F raw "$OVERLAY" >/dev/null
+fi
+
+echo ""
+echo "=== Launching test VM ==="
+if [[ -n "$EJECT" ]]; then
+    echo "  Disk:    $DISK_FILE (/dev/vda, USB ejected)"
+else
+    echo "  Image:   $IMAGE_FILE"
+    echo "  Overlay: $OVERLAY (temporary)"
+    if [[ -n "$DISK_SIZE" ]]; then
+        echo "  Disk:    $DISK_FILE (/dev/vda, USB image is /dev/vdb)"
+    fi
+fi
+echo "  Memory:  ${MEMORY} MB"
+echo "  CPUs:    $CPUS"
+echo "  Display: $DISPLAY_TYPE"
+if [[ -n "$NO_NETWORK" ]]; then
+    echo "  Network: disabled (air-gapped)"
+else
+    echo "  SSH:     ssh -o StrictHostKeyChecking=no -p $SSH_PORT user@localhost"
+fi
+echo ""
+if [[ "$DISPLAY_TYPE" == "none" ]]; then
+    echo "  (headless mode — serial console below, Ctrl-A X to quit)"
+    echo ""
+fi
+
+DISPLAY_ARGS=()
+case "$DISPLAY_TYPE" in
+    none)
+        DISPLAY_ARGS=(-display none -serial stdio)
+        ;;
+    gtk)
+        DISPLAY_ARGS=(-display gtk,grab-on-hover=on)
+        ;;
+    sdl)
+        DISPLAY_ARGS=(-display sdl)
+        ;;
+    *)
+        DISPLAY_ARGS=(-display "$DISPLAY_TYPE")
+        ;;
+esac
+
+DISK_ARGS=()
+USB_ARGS=()
+if [[ -n "$EJECT" ]]; then
+    # Eject mode: only the persistent disk, no USB image
+    DISK_ARGS=(-drive if=virtio,file="$DISK_FILE",format=qcow2)
+elif [[ -n "$DISK_SIZE" ]]; then
+    # Use bootindex to prioritize persistent disk over USB image
+    DISK_ARGS=(-drive id=disk0,if=none,file="$DISK_FILE",format=qcow2
+               -device virtio-blk-pci,drive=disk0,bootindex=0)
+    USB_ARGS=(-drive id=usb0,if=none,file="$OVERLAY",format=qcow2
+              -device virtio-blk-pci,drive=usb0,bootindex=1)
+else
+    USB_ARGS=(-drive if=virtio,file="$OVERLAY",format=qcow2)
+fi
+
+NET_ARGS=()
+if [[ -n "$NO_NETWORK" ]]; then
+    NET_ARGS=(-nic none)
+else
+    NET_ARGS=(-netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22"
+              -device virtio-net-pci,netdev=net0)
+fi
+
+qemu-system-x86_64 \
+    -cpu host \
+    $KVM_FLAG \
+    -m "$MEMORY" \
+    -smp "$CPUS" \
+    "${DISK_ARGS[@]}" \
+    "${USB_ARGS[@]}" \
+    -drive if=pflash,format=raw,readonly=on,file="$OVMF_CODE" \
+    -drive if=pflash,format=raw,file="$NVRAM" \
+    -device virtio-vga \
+    "${NET_ARGS[@]}" \
+    "${DISPLAY_ARGS[@]}"
+
+echo ""
+echo "VM exited. Overlay discarded."

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,365 @@
+{
+  "nodes": {
+    "blog-rymcg-tech": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771529176,
+        "narHash": "sha256-0m+Gx6wz37U7VGWmjHEGwpwuQ6XEqhzVC/Tld1OZrFg=",
+        "owner": "EnigmaCurry",
+        "repo": "blog.rymcg.tech",
+        "rev": "e96c77d360a036ac5ea91168856b6083bcbaf8aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "EnigmaCurry",
+        "repo": "blog.rymcg.tech",
+        "type": "github"
+      }
+    },
+    "emacs_enigmacurry": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771577167,
+        "narHash": "sha256-5jQ4gOuSkYnPAGaweMqSNBVnr7iRprx7YYKUfjxt6Kw=",
+        "owner": "EnigmaCurry",
+        "repo": "emacs",
+        "rev": "12969bdd6580a23dcd82a3e3b4eb428f886e0c01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "EnigmaCurry",
+        "repo": "emacs",
+        "type": "github"
+      }
+    },
+    "firefox-addons": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "dir": "pkgs/firefox-addons",
+        "lastModified": 1771591358,
+        "narHash": "sha256-17QxUvLnI/dVy6Qi3EmJfJdmyRLtNCbnxtms4wAAjkU=",
+        "owner": "rycee",
+        "repo": "nur-expressions",
+        "rev": "66abfa0001c1983e08589b1c89dae346f8f80ccc",
+        "type": "gitlab"
+      },
+      "original": {
+        "dir": "pkgs/firefox-addons",
+        "owner": "rycee",
+        "repo": "nur-expressions",
+        "type": "gitlab"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "git-prompt": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-kV63N7WFRfPMN1VbBqzEdaskUfkCDb+ZpvggScfuJ3c=",
+        "type": "file",
+        "url": "https://raw.githubusercontent.com/git/git/master/contrib/completion/git-prompt.sh"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://raw.githubusercontent.com/git/git/master/contrib/completion/git-prompt.sh"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771531206,
+        "narHash": "sha256-1R3Wx6KUkMb4x4E5UOhW9p6rqiexzSGGWxZqSHqW5n0=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "91be7cce763fa4022c7cf025a71b0c366d1b6e77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_2": {
+      "inputs": {
+        "nixpkgs": [
+          "sway-home",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770260404,
+        "narHash": "sha256-3iVX1+7YUIt23hBx1WZsUllhbmP2EnXrV8tCRbLxHc8=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "0d782ee42c86b196acff08acfbf41bb7d13eed5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-25.11",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-flatpak": {
+      "locked": {
+        "lastModified": 1768656715,
+        "narHash": "sha256-Sbh037scxKFm7xL0ahgSCw+X2/5ZKeOwI2clqrYr9j4=",
+        "owner": "gmodena",
+        "repo": "nix-flatpak",
+        "rev": "123fe29340a5b8671367055b75a6e7c320d6f89a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gmodena",
+        "repo": "nix-flatpak",
+        "type": "github"
+      }
+    },
+    "nix-flatpak_2": {
+      "locked": {
+        "lastModified": 1768656715,
+        "narHash": "sha256-Sbh037scxKFm7xL0ahgSCw+X2/5ZKeOwI2clqrYr9j4=",
+        "owner": "gmodena",
+        "repo": "nix-flatpak",
+        "rev": "123fe29340a5b8671367055b75a6e7c320d6f89a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gmodena",
+        "repo": "nix-flatpak",
+        "type": "github"
+      }
+    },
+    "nixos-vm-template": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1770161652,
+        "narHash": "sha256-pbJ8McY5bbJT+Te286MGyAGU+LnB0X1Xr95BBn+fTcA=",
+        "owner": "EnigmaCurry",
+        "repo": "nixos-vm-template",
+        "rev": "7837bbaff84985adb2e69c9fee6f4aa4e1729ad2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "EnigmaCurry",
+        "repo": "nixos-vm-template",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1769461804,
+        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_unstable": {
+      "locked": {
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "org-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1769553261,
+        "narHash": "sha256-z8OlxrhZRDEqZSEW0HhdTdUEIbOySMdiMF8MvAlsM+Q=",
+        "owner": "EnigmaCurry",
+        "repo": "org",
+        "rev": "9c1c5c7cf83461e7fae740e297fcc7e38fb13bd4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "EnigmaCurry",
+        "repo": "org",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "firefox-addons": "firefox-addons",
+        "home-manager": "home-manager",
+        "nix-flatpak": "nix-flatpak",
+        "nixpkgs": "nixpkgs",
+        "org-src": "org-src",
+        "sway-home": "sway-home",
+        "sway-home-src": "sway-home-src",
+        "vendor-git-repos": "vendor-git-repos"
+      }
+    },
+    "script-wizard": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1769806370,
+        "narHash": "sha256-2OUSEa4l2tS92+idjIuysJ7s5BKUzrgUEBM+673EXvg=",
+        "owner": "EnigmaCurry",
+        "repo": "script-wizard",
+        "rev": "e55e3601077cf71f15db4d2e2a069af77ff685b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "EnigmaCurry",
+        "repo": "script-wizard",
+        "type": "github"
+      }
+    },
+    "sway-home": {
+      "inputs": {
+        "blog-rymcg-tech": "blog-rymcg-tech",
+        "emacs_enigmacurry": "emacs_enigmacurry",
+        "git-prompt": "git-prompt",
+        "home-manager": "home-manager_2",
+        "nix-flatpak": "nix-flatpak_2",
+        "nixos-vm-template": "nixos-vm-template",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs_unstable": "nixpkgs_unstable",
+        "script-wizard": "script-wizard",
+        "sway-home": "sway-home_2"
+      },
+      "locked": {
+        "dir": "home-manager",
+        "lastModified": 1771617184,
+        "narHash": "sha256-F7m7znsjTiq78TMG7dFKfSoCN7mvK/Mn6psYe6RUVZc=",
+        "owner": "EnigmaCurry",
+        "repo": "sway-home",
+        "rev": "e3048fa0dbc16e2e8f850b4bf26a5c4b2b4c851f",
+        "type": "github"
+      },
+      "original": {
+        "dir": "home-manager",
+        "owner": "EnigmaCurry",
+        "repo": "sway-home",
+        "type": "github"
+      }
+    },
+    "sway-home-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771617184,
+        "narHash": "sha256-F7m7znsjTiq78TMG7dFKfSoCN7mvK/Mn6psYe6RUVZc=",
+        "owner": "EnigmaCurry",
+        "repo": "sway-home",
+        "rev": "e3048fa0dbc16e2e8f850b4bf26a5c4b2b4c851f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "EnigmaCurry",
+        "repo": "sway-home",
+        "type": "github"
+      }
+    },
+    "sway-home_2": {
+      "flake": false,
+      "locked": {
+        "path": "..",
+        "type": "path"
+      },
+      "original": {
+        "path": "..",
+        "type": "path"
+      },
+      "parent": [
+        "sway-home"
+      ]
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "vendor-git-repos": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771269639,
+        "narHash": "sha256-FkTe9MHIw5ZGrhfRW4HCyEvo7RDU0Z9mM32lBYBrc/E=",
+        "owner": "EnigmaCurry",
+        "repo": "d.rymcg.tech",
+        "rev": "b48a441eb38bdbd275f77ae7c35d57b8762d179e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "EnigmaCurry",
+        "repo": "d.rymcg.tech",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,71 @@
+{
+  description = "d.rymcg.tech - Docker server infrastructure and workstation USB image";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    sway-home = {
+      url = "github:EnigmaCurry/sway-home?dir=home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nix-flatpak.url = "github:gmodena/nix-flatpak";
+
+    # Full sway-home repo (the sway-home input above is just the home-manager subdir)
+    sway-home-src = {
+      url = "github:EnigmaCurry/sway-home";
+      flake = false;
+    };
+    # Repos not already available via sway-home.inputs
+    org-src = {
+      url = "github:EnigmaCurry/org";
+      flake = false;
+    };
+
+    # Bare git repos for offline workstation (overridden at build time)
+    vendor-git-repos = {
+      url = "github:EnigmaCurry/d.rymcg.tech";  # placeholder, overridden at build time
+      flake = false;
+    };
+
+    # Firefox extensions
+    firefox-addons = {
+      url = "gitlab:rycee/nur-expressions?dir=pkgs/firefox-addons";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, home-manager, sway-home, nix-flatpak
+    , sway-home-src, org-src, vendor-git-repos, firefox-addons, ... }@inputs:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      # Access sway-home's own inputs (emacs, blog, nixos-vm-template, etc.)
+      swayHomeInputs = sway-home.inputs;
+
+      workstationSettings = import ./nix/workstation/settings.nix;
+
+      commonSpecialArgs = {
+        inherit self nixpkgs home-manager sway-home swayHomeInputs nix-flatpak;
+        inherit sway-home-src org-src vendor-git-repos firefox-addons;
+        inherit (workstationSettings) hostName userName remotes;
+      };
+
+      commonModules = [
+        home-manager.nixosModules.home-manager
+        ./nix/workstation/configuration.nix
+      ];
+    in
+    {
+      nixosConfigurations.workstation = nixpkgs.lib.nixosSystem {
+        inherit system;
+        specialArgs = commonSpecialArgs // {
+          inherit (workstationSettings) sudoUser;
+        };
+        modules = commonModules;
+      };
+    };
+}

--- a/nix/workstation/archive.nix
+++ b/nix/workstation/archive.nix
@@ -1,0 +1,247 @@
+# Archive data management for the workstation USB
+# Handles GC root symlinks and helper scripts for the Docker image archive,
+# ISOs, and Docker CE packages that are copied in post-install.
+{ config, lib, pkgs, userName, ... }:
+
+let
+  # Helper script: show what data is bundled on this workstation
+  workstation-usb-info = pkgs.writeShellScriptBin "workstation-usb-info" ''
+    echo "=== Workstation USB Info ==="
+    echo ""
+
+    gcroot_dir="/nix/var/nix/gcroots"
+
+    # Per-project Docker image GC roots
+    echo "Docker images:"
+    img_count=0
+    for root in "$gcroot_dir"/workstation-usb-image-*; do
+      [[ -L "$root" ]] || continue
+      name=$(basename "$root")
+      proj="''${name#workstation-usb-image-}"
+      target=$(readlink "$root")
+      size=$(du -sh "$target" 2>/dev/null | cut -f1)
+      echo "  $proj: $target ($size)"
+      img_count=$((img_count + 1))
+    done
+
+    # ComfyUI variant files
+    for root in "$gcroot_dir"/workstation-usb-comfyui-*; do
+      [[ -L "$root" ]] || continue
+      name=$(basename "$root")
+      filename="''${name#workstation-usb-comfyui-}"
+      target=$(readlink "$root")
+      size=$(du -sh "$target" 2>/dev/null | cut -f1)
+      echo "  comfyui/$filename ($size)"
+      img_count=$((img_count + 1))
+    done
+
+    # Legacy monolithic archive
+    legacy_root="$gcroot_dir/workstation-usb-archive"
+    if [[ -L "$legacy_root" ]]; then
+      target=$(readlink "$legacy_root")
+      size=$(du -sh "$target" 2>/dev/null | cut -f1)
+      echo "  (legacy archive): $target ($size)"
+      img_count=$((img_count + 1))
+    fi
+
+    if [[ $img_count -eq 0 ]]; then
+      echo "  (none)"
+    fi
+
+    echo ""
+
+    # Show ISOs if present
+    isos_root="$gcroot_dir/workstation-usb-isos"
+    if [[ -L "$isos_root" ]]; then
+      target=$(readlink "$isos_root")
+      echo "ISOs:"
+      ls -lh "$target"/*.iso 2>/dev/null | awk '{print "  " $NF " (" $5 ")"}'
+    else
+      echo "ISOs: not installed"
+    fi
+
+    echo ""
+
+    # Show Docker CE packages if present
+    docker_root="$gcroot_dir/workstation-usb-docker-packages"
+    if [[ -L "$docker_root" ]]; then
+      target=$(readlink "$docker_root")
+      echo "Docker CE packages:"
+      find "$target" -name '*.deb' -o -name '*.rpm' 2>/dev/null | while read f; do
+        echo "  $(basename "$f") ($(du -h "$f" | cut -f1))"
+      done
+    else
+      echo "Docker CE packages: not installed"
+    fi
+  '';
+
+  # Helper script: clone this workstation USB to another device
+  # Note: cannot reference config.system.build.toplevel here — that would
+  # create an infinite recursion (toplevel depends on systemPackages which
+  # includes this script). Use /run/current-system at runtime instead.
+  workstation-usb-clone = pkgs.writeShellScriptBin "workstation-usb-clone" ''
+    set -eo pipefail
+    # Prefer the writable repo clone if available
+    REPO_SCRIPT="/home/${userName}/git/vendor/enigmacurry/d.rymcg.tech/nix/workstation/installer/clone-to-device.sh"
+    # Fall back to the nix store copy bundled alongside this module
+    NIX_SCRIPT="${./installer/clone-to-device.sh}"
+    if [[ -x "$REPO_SCRIPT" ]]; then
+      CLONE_SCRIPT="$REPO_SCRIPT"
+    else
+      CLONE_SCRIPT="$NIX_SCRIPT"
+    fi
+    if [[ $EUID -ne 0 ]]; then
+      exec sudo "$CLONE_SCRIPT" "$@"
+    fi
+    exec "$CLONE_SCRIPT" "$@"
+  '';
+
+  # Helper script: restore archived Docker images
+  workstation-usb-restore-images = pkgs.writeShellScriptBin "workstation-usb-restore-images" ''
+    set -euo pipefail
+    archive_dir="/var/workstation/images/x86_64"
+    if [[ ! -d "$archive_dir" ]] || [[ -z "$(ls -A "$archive_dir" 2>/dev/null)" ]]; then
+      echo "Error: No Docker image archive found on this workstation." >&2
+      echo "Run workstation-usb-post-install to copy archive data." >&2
+      exit 1
+    fi
+
+    # Check for d.rymcg.tech CLI
+    drymcg=$(command -v d.rymcg.tech 2>/dev/null || true)
+    if [[ -z "$drymcg" ]]; then
+      echo "Error: d.rymcg.tech CLI not found in PATH." >&2
+      echo "Add ~/git/vendor/enigmacurry/d.rymcg.tech/_scripts/user to PATH." >&2
+      exit 1
+    fi
+
+    echo "Restoring Docker images from: $archive_dir"
+    exec d.rymcg.tech image-restore --archive-dir="$archive_dir" "$@"
+  '';
+
+in
+{
+  environment.systemPackages = [
+    workstation-usb-info
+    workstation-usb-clone
+    workstation-usb-restore-images
+  ];
+
+  # Create data directories for symlinks to GC-rooted store paths
+  # Layout matches _archive/ so d.rymcg.tech tools work with the symlink
+  systemd.tmpfiles.rules = [
+    "d /var/workstation 0755 root root -"
+    "d /var/workstation/images 0755 root root -"
+    "d /var/workstation/images/x86_64 0755 root root -"
+    "d /var/workstation/isos 0755 root root -"
+    "d /var/workstation/docker-packages 0755 root root -"
+  ];
+
+  # On boot, create convenience symlinks from /var/workstation/* to GC-rooted store paths
+  systemd.services.workstation-usb-archive-links = {
+    description = "Create symlinks to workstation archive data";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "local-fs.target" "workstation-clone-repos.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      gcroot_dir="/nix/var/nix/gcroots"
+
+      # Symlink _archive in the writable d.rymcg.tech clone to /var/workstation
+      clone_dir="/home/${userName}/git/vendor/enigmacurry/d.rymcg.tech"
+      archive_link="$clone_dir/_archive"
+      if [[ -d "$clone_dir" ]] && [[ ! -e "$archive_link" ]]; then
+        ln -sfn /var/workstation "$archive_link"
+        chown -h ${userName}: "$archive_link"
+        echo "_archive: linked -> /var/workstation"
+      fi
+
+      # Per-project Docker image directories
+      for root in "$gcroot_dir"/workstation-usb-image-*; do
+        [[ -L "$root" ]] || continue
+        name=$(basename "$root")
+        proj="''${name#workstation-usb-image-}"
+        store_path=$(readlink "$root")
+        if [[ ! -d "$store_path" ]]; then
+          echo "$proj: WARNING store path $store_path does not exist!"
+          continue
+        fi
+        ln -sfn "$store_path" "/var/workstation/images/x86_64/$proj"
+        echo "$proj: linked -> $store_path"
+      done
+
+      # Docker image manifest
+      manifest_root="$gcroot_dir/workstation-usb-image-manifest"
+      if [[ -L "$manifest_root" ]]; then
+        store_path=$(readlink "$manifest_root")
+        if [[ -e "$store_path" ]]; then
+          ln -sfn "$store_path" "/var/workstation/images/x86_64/manifest.json"
+          echo "manifest.json: linked"
+        fi
+      fi
+
+      # ComfyUI variant files (individual .tar.gz files in the store)
+      comfyui_count=0
+      for root in "$gcroot_dir"/workstation-usb-comfyui-*; do
+        [[ -L "$root" ]] || continue
+        name=$(basename "$root")
+        filename="''${name#workstation-usb-comfyui-}"
+        store_path=$(readlink "$root")
+        if [[ ! -e "$store_path" ]]; then
+          echo "comfyui/$filename: WARNING store path does not exist!"
+          continue
+        fi
+        mkdir -p "/var/workstation/images/x86_64/comfyui"
+        ln -sfn "$store_path" "/var/workstation/images/x86_64/comfyui/$filename"
+        comfyui_count=$((comfyui_count + 1))
+      done
+      [[ $comfyui_count -gt 0 ]] && echo "comfyui: linked $comfyui_count variant files"
+
+      # Legacy: monolithic archive GC root (backward compat)
+      legacy_root="$gcroot_dir/workstation-usb-archive"
+      if [[ -L "$legacy_root" ]]; then
+        store_path=$(readlink "$legacy_root")
+        if [[ -d "$store_path" ]]; then
+          count=0
+          for item in "$store_path"/*; do
+            [[ -e "$item" ]] || continue
+            ln -sfn "$item" "/var/workstation/images/x86_64/$(basename "$item")"
+            count=$((count + 1))
+          done
+          echo "legacy archive: linked $count items"
+        fi
+      fi
+
+      # ISOs
+      isos_root="$gcroot_dir/workstation-usb-isos"
+      if [[ -L "$isos_root" ]]; then
+        store_path=$(readlink "$isos_root")
+        if [[ -d "$store_path" ]]; then
+          count=0
+          for item in "$store_path"/*; do
+            [[ -e "$item" ]] || continue
+            ln -sfn "$item" "/var/workstation/isos/$(basename "$item")"
+            count=$((count + 1))
+          done
+          echo "ISOs: linked $count items"
+        fi
+      fi
+
+      # Docker CE packages
+      docker_root="$gcroot_dir/workstation-usb-docker-packages"
+      if [[ -L "$docker_root" ]]; then
+        store_path=$(readlink "$docker_root")
+        if [[ -d "$store_path" ]]; then
+          count=0
+          for item in "$store_path"/*; do
+            [[ -e "$item" ]] || continue
+            ln -sfn "$item" "/var/workstation/docker-packages/$(basename "$item")"
+            count=$((count + 1))
+          done
+          echo "Docker packages: linked $count items"
+        fi
+      fi
+    '';
+  };
+}

--- a/nix/workstation/boot.nix
+++ b/nix/workstation/boot.nix
@@ -1,0 +1,76 @@
+# Boot configuration for USB workstation
+{ config, lib, pkgs, ... }:
+
+{
+  # Use latest kernel for broadest hardware support
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+
+  # UEFI systemd-boot
+  boot.loader.systemd-boot.enable = true;
+  # Critical: don't modify host machine's UEFI NVRAM
+  boot.loader.efi.canTouchEfiVariables = false;
+
+  # Auto-grow root partition to fill the device on first boot.
+  # Custom service replaces boot.growPartition to handle LUKS and btrfs.
+  # The "nixos" partition is found by partlabel, grown to fill the disk,
+  # then any LUKS container and filesystem are resized to match.
+  systemd.services.growpart = {
+    wantedBy = [ "-.mount" ];
+    after = [ "-.mount" ];
+    before = [ "systemd-growfs-root.service" "shutdown.target" ];
+    conflicts = [ "shutdown.target" ];
+    unitConfig.DefaultDependencies = false;
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      TimeoutSec = "infinity";
+    };
+    script = ''
+      set -euo pipefail
+      PART=$(readlink -f /dev/disk/by-partlabel/nixos)
+      # Extract parent device and partition number
+      parent="$PART"
+      while [ "''${parent%[0-9]}" != "''${parent}" ]; do
+        parent="''${parent%[0-9]}"
+      done
+      partNum="''${PART#"''${parent}"}"
+      # Handle NVMe "p" separator (e.g. /dev/nvme0n1p2)
+      if [ "''${parent%[0-9]p}" != "''${parent}" ] && [ -b "''${parent%p}" ]; then
+        parent="''${parent%p}"
+      fi
+
+      # Grow the physical partition
+      # Exit 0 = grew, exit 1 = already full size (NOCHANGE)
+      rc=0
+      ${pkgs.cloud-utils.guest}/bin/growpart "$parent" "$partNum" || rc=$?
+      if [ "$rc" -eq 1 ]; then
+        echo "Partition already full size, nothing to do."
+        exit 0
+      elif [ "$rc" -ne 0 ]; then
+        exit "$rc"
+      fi
+
+      # Partition grew — resize LUKS dm-crypt mapping if present.
+      # Reloads the dm table with updated sector count. The key (stored in
+      # the kernel keyring) is referenced by the table and stays untouched.
+      if ${pkgs.cryptsetup}/bin/cryptsetup status cryptroot >/dev/null 2>&1; then
+        old_table=$(${pkgs.lvm2}/bin/dmsetup table cryptroot)
+        luks_offset=$(echo "$old_table" | ${pkgs.gawk}/bin/awk '{print $8}')
+        new_part_sectors=$(${pkgs.util-linux}/bin/blockdev --getsz /dev/disk/by-partlabel/nixos)
+        new_data_sectors=$((new_part_sectors - luks_offset))
+        new_table=$(echo "$old_table" | ${pkgs.gawk}/bin/awk -v ns="$new_data_sectors" '{$2=ns; print}')
+        ${pkgs.lvm2}/bin/dmsetup suspend cryptroot
+        ${pkgs.lvm2}/bin/dmsetup load cryptroot --table "$new_table"
+        ${pkgs.lvm2}/bin/dmsetup resume cryptroot
+      fi
+
+      # Resize the filesystem to fill the new space
+      ROOT_DEV=$(${pkgs.util-linux}/bin/findmnt -nro SOURCE /)
+      FSTYPE=$(${pkgs.util-linux}/bin/findmnt -nro FSTYPE /)
+      case "$FSTYPE" in
+        btrfs) ${pkgs.btrfs-progs}/bin/btrfs filesystem resize max / ;;
+        ext*)  ${pkgs.e2fsprogs}/bin/resize2fs "$ROOT_DEV" ;;
+      esac
+    '';
+  };
+}

--- a/nix/workstation/configuration.nix
+++ b/nix/workstation/configuration.nix
@@ -1,0 +1,55 @@
+# Main NixOS configuration for the workstation USB
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ./hardware.nix
+    ./boot.nix
+    ./users.nix
+    ./networking.nix
+    ./docker.nix
+    ./desktop.nix
+    ./home-manager.nix
+    ./workstation-packages.nix
+    ./repos.nix
+    ./archive.nix
+    ./first-boot.nix
+  ];
+
+  system.stateVersion = "25.11";
+  nixpkgs.hostPlatform = "x86_64-linux";
+
+  # Filesystem labels (must match what install-to-device.sh and
+  # workstation-usb-image create: ESP label "ESP", root label "nixos")
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "auto";
+    options = [ "noatime" ];  # prevent write-on-read (critical for USB longevity)
+  };
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-label/ESP";
+    fsType = "vfat";
+    options = [ "umask=0077" "noatime" ];
+  };
+
+  # Reduce journal writes to disk (volatile = in-memory only)
+  services.journald.storage = "volatile";
+  services.journald.extraConfig = ''
+    RuntimeMaxUse=64M
+  '';
+
+  # Enable flakes
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+
+  # Allow unfree packages (firmware, fonts, etc.)
+  nixpkgs.config.allowUnfree = true;
+
+  # /bin/bash symlink for scripts with #!/bin/bash shebangs
+  systemd.tmpfiles.rules = [
+    "L+ /bin/bash - - - - ${pkgs.bash}/bin/bash"
+  ];
+
+  # Timezone and locale
+  time.timeZone = "UTC";
+  i18n.defaultLocale = "en_US.UTF-8";
+}

--- a/nix/workstation/desktop.nix
+++ b/nix/workstation/desktop.nix
@@ -1,0 +1,108 @@
+# Sway desktop environment with greetd login
+{ config, lib, pkgs, nix-flatpak, ... }:
+
+{
+  imports = [
+    nix-flatpak.nixosModules.nix-flatpak
+  ];
+
+  # Sway window manager
+  programs.sway = {
+    enable = true;
+    wrapperFeatures.gtk = true;
+  };
+
+  # Console login manager -> sway
+  services.greetd = {
+    enable = true;
+    settings = {
+      default_session = {
+        command = "${pkgs.tuigreet}/bin/tuigreet --time --cmd sway";
+        user = "greeter";
+      };
+    };
+  };
+
+  # PipeWire audio
+  services.pipewire = {
+    enable = true;
+    alsa.enable = true;
+    pulse.enable = true;
+  };
+  # Required for PipeWire
+  security.rtkit.enable = true;
+
+  # XDG portals for sway
+  xdg.portal = {
+    enable = true;
+    wlr.enable = true;
+    extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
+  };
+
+  # Fonts
+  fonts.packages = with pkgs; [
+    noto-fonts
+    noto-fonts-cjk-sans
+    noto-fonts-color-emoji
+    fira-code
+    fira-code-symbols
+    jetbrains-mono
+    font-awesome
+    liberation_ttf
+    dejavu_fonts
+  ];
+
+  # Firefox system-level policies (locked, cannot be changed in GUI)
+  programs.firefox = {
+    enable = true;
+    policies = {
+      DisableTelemetry = true;
+      DisablePocket = true;
+      DisableFirefoxStudies = true;
+      DisableFirefoxScreenshots = true;
+      DontCheckDefaultBrowser = true;
+      NoDefaultBookmarks = true;
+      OfferToSaveLogins = false;
+      PasswordManagerEnabled = false;
+      NewTabPage = false;
+      FirefoxHome = {
+        Search = false;
+        TopSites = false;
+        SponsoredTopSites = false;
+        Highlights = false;
+        Pocket = false;
+        SponsoredPocket = false;
+        Snippets = false;
+        Locked = true;
+      };
+      UserMessaging = {
+        WhatsNew = false;
+        ExtensionRecommendations = false;
+        FeatureRecommendations = false;
+        UrlbarInterventions = false;
+        SkipOnboarding = true;
+        MoreFromMozilla = false;
+        Locked = true;
+      };
+    };
+  };
+
+  # Flatpak: system-level flathub remote (Bazaar needs this)
+  # Packages are installed via home-manager in home-manager.nix
+  services.flatpak = {
+    enable = true;
+    remotes = [
+      { name = "flathub"; location = "https://dl.flathub.org/repo/flathub.flatpakrepo"; }
+    ];
+  };
+
+  # Thunar file manager with volume management
+  programs.thunar = {
+    enable = true;
+    plugins = with pkgs; [ thunar-volman thunar-archive-plugin ];
+  };
+  services.gvfs.enable = true;  # trash, network mounts, etc.
+
+  # Allow user graphical sessions
+  hardware.graphics.enable = true;
+}

--- a/nix/workstation/docker.nix
+++ b/nix/workstation/docker.nix
@@ -1,0 +1,22 @@
+# Docker and libvirt configuration for the workstation
+{ config, lib, pkgs, userName, ... }:
+
+{
+  # Install Docker CLI without enabling the daemon service
+  virtualisation.docker.enable = true;
+  systemd.services.docker.wantedBy = lib.mkForce [];
+  systemd.sockets.docker.wantedBy = lib.mkForce [];
+
+  # Enable libvirtd for virt-manager / QEMU / KVM
+  virtualisation.libvirtd.enable = true;
+
+  # Grant the primary user local docker and libvirtd access
+  users.users.${userName}.extraGroups = [ "docker" "libvirtd" ];
+
+  # Traefik UID reservation for Docker containers
+  users.users.traefik = {
+    isSystemUser = true;
+    group = "traefik";
+  };
+  users.groups.traefik = {};
+}

--- a/nix/workstation/first-boot.nix
+++ b/nix/workstation/first-boot.nix
@@ -1,0 +1,61 @@
+# Flake input pinning and offline rebuild support
+#
+# Pins flake inputs so nixos-install copies them to targets,
+# enabling offline nixos-rebuild on the installed system.
+{ config, lib, pkgs, nixpkgs, home-manager, self
+, sway-home, swayHomeInputs, nix-flatpak, sway-home-src, org-src
+, vendor-git-repos, firefox-addons, userName, ... }:
+
+let
+  # List all flake inputs so they become runtime dependencies of the system
+  # closure (and thus get copied by nixos-install). The /etc file creates
+  # a reference that prevents garbage collection.
+  flakeInputPaths = lib.concatStringsSep "\n" [
+    "${nixpkgs}"
+    "${home-manager}"
+    "${sway-home}"
+    "${nix-flatpak}"
+    "${firefox-addons}"
+    "${sway-home-src}"
+    "${org-src}"
+    "${vendor-git-repos}"
+    "${self}"
+    "${swayHomeInputs.emacs_enigmacurry}"
+    "${swayHomeInputs.blog-rymcg-tech}"
+    "${swayHomeInputs.nixos-vm-template}"
+    "${swayHomeInputs.script-wizard}"
+  ];
+
+  # Wrapper that makes `nixos-rebuild switch` (etc.) just work by
+  # injecting --flake and --override-input automatically.
+  # References the real nixos-rebuild by store path to avoid recursion.
+  realNixosRebuild = "${pkgs.nixos-rebuild}/bin/nixos-rebuild";
+  nixos-rebuild-wrapper = pkgs.writeShellScriptBin "nixos-rebuild" ''
+    set -euo pipefail
+    FLAKE_DIR="/home/${userName}/git/vendor/enigmacurry/d.rymcg.tech"
+    if [[ ! -d "$FLAKE_DIR/.git" ]]; then
+      echo "Error: $FLAKE_DIR not found (workstation-clone-repos must run first)" >&2
+      exit 1
+    fi
+    export HOME="''${HOME:-/root}"
+    ${pkgs.git}/bin/git config --global --add safe.directory "$FLAKE_DIR"
+    # Temporarily clear skip-worktree so nix sees local settings.nix edits
+    ${pkgs.git}/bin/git -C "$FLAKE_DIR" update-index --no-skip-worktree nix/workstation/settings.nix 2>/dev/null || true
+    ${realNixosRebuild} "$@" \
+      --flake "$FLAKE_DIR#workstation" \
+      --override-input vendor-git-repos "${vendor-git-repos}"
+    _rc=$?
+    # Restore skip-worktree to keep git status clean
+    ${pkgs.git}/bin/git -C "$FLAKE_DIR" update-index --skip-worktree nix/workstation/settings.nix 2>/dev/null || true
+    exit $_rc
+  '';
+
+in
+{
+  # Pin all flake inputs into the system closure so they survive nixos-install
+  # and are available for offline nixos-rebuild on the target
+  environment.etc."workstation/flake-inputs".text = flakeInputPaths;
+
+  # Replace bare nixos-rebuild with our flake-aware wrapper
+  environment.systemPackages = [ nixos-rebuild-wrapper ];
+}

--- a/nix/workstation/hardware.nix
+++ b/nix/workstation/hardware.nix
@@ -1,0 +1,59 @@
+# Hardware support for real x86_64 machines (USB boot)
+{ config, lib, pkgs, ... }:
+
+{
+  # Redistributable firmware (WiFi, GPU, etc.)
+  hardware.enableRedistributableFirmware = true;
+
+  # initrd modules — only what's needed to find and mount root filesystem
+  # (GPU drivers load after boot from rootfs, keeping initrd small)
+  boot.initrd.availableKernelModules = [
+    # USB storage
+    "usb_storage" "uas"
+    # SATA/NVMe
+    "ahci" "nvme"
+    # USB host controllers
+    "xhci_pci" "ehci_pci"
+    # Filesystems needed at boot
+    "ext4" "btrfs" "crc32c-cryptoapi" "vfat"
+    # LUKS / dm-crypt (for optional encryption)
+    "dm_mod" "dm_crypt"
+    "aes" "aes_generic" "xts" "ecb" "sha256"
+    # Virtio (for VM testing)
+    "virtio_pci" "virtio_blk" "virtio_scsi" "virtio_net"
+  ];
+
+  # Include cryptsetup in initrd for optional LUKS support
+  boot.initrd.extraUtilsCommands = ''
+    copy_bin_and_libs ${pkgs.cryptsetup}/bin/cryptsetup
+  '';
+
+  # Conditionally open LUKS if the root partition is encrypted.
+  # Runs after device discovery, before root filesystem mount.
+  # For unencrypted systems, cryptsetup isLuks returns false and this is a no-op.
+  boot.initrd.postDeviceCommands = lib.mkAfter ''
+    if cryptsetup isLuks /dev/disk/by-partlabel/nixos 2>/dev/null; then
+      echo "Opening encrypted root partition..."
+      cryptsetup luksOpen /dev/disk/by-partlabel/nixos cryptroot
+      udevadm settle
+    fi
+  '';
+
+  # Kernel modules loaded after boot (GPU, KVM, WiFi)
+  boot.kernelModules = [
+    "kvm-intel" "kvm-amd"
+    "iwlwifi"
+    "i915" "amdgpu" "nouveau"
+  ];
+
+  # Bluetooth
+  hardware.bluetooth.enable = true;
+  services.blueman.enable = true;
+
+  # zram swap (compressed in-memory swap)
+  zramSwap = {
+    enable = true;
+    memoryPercent = 50;
+    algorithm = "zstd";
+  };
+}

--- a/nix/workstation/home-manager.nix
+++ b/nix/workstation/home-manager.nix
@@ -1,0 +1,211 @@
+# Home-manager integration using sway-home modules
+# Follows the pattern from nixos-vm-template/profiles/home-manager.nix
+{ config, lib, pkgs, sway-home, swayHomeInputs, nix-flatpak, firefox-addons, userName, ... }:
+
+{
+  # Enable verbose logging so home-manager activation failures are visible in journalctl
+  systemd.services."home-manager-${userName}" = {
+    serviceConfig.Environment = lib.mkAfter [ "VERBOSE=1" ];
+  };
+
+  home-manager = {
+    useGlobalPkgs = true;
+    useUserPackages = true;
+
+    # Pass inputs that sway-home modules expect
+    extraSpecialArgs = {
+      inputs = swayHomeInputs;
+      inherit userName;
+    };
+
+    # Configure home-manager for the regular user
+    users.${userName} = { pkgs, ... }:
+    let
+      # Pre-compiled vterm native module — NixOS can't build it via straight.el
+      # because cmake can't find standard library paths in the nix store.
+      # Installs vterm-module.so into the user profile's share/emacs/site-lisp/
+      # which is on emacs's default load-path.
+      emacs-vterm-module = pkgs.runCommand "emacs-vterm-module" {} ''
+        mkdir -p $out/share/emacs/site-lisp
+        find ${pkgs.emacsPackages.vterm} -name 'vterm-module.so' \
+          -exec cp {} $out/share/emacs/site-lisp/ \;
+      '';
+    in
+    {
+      imports = [
+        nix-flatpak.homeManagerModules.nix-flatpak
+        sway-home.homeModules.home
+        sway-home.homeModules.emacs
+        sway-home.homeModules.rust
+        sway-home.homeModules.nixos-vm-template
+      ];
+
+      # Flatpak: configure unconditionally (sway-home's module uses
+      # builtins.pathExists which checks the build host, not the target)
+      services.flatpak = {
+        enable = true;
+        remotes = [
+          { name = "flathub"; location = "https://dl.flathub.org/repo/flathub.flatpakrepo"; }
+        ];
+        packages = [
+          "io.github.kolunmi.Bazaar"
+        ];
+        update.onActivation = true;
+      };
+
+      # Install packages from sway-home + home-manager CLI (mutable system)
+      home.packages = import "${sway-home}/modules/packages.nix" { inherit pkgs; }
+        ++ [ swayHomeInputs.script-wizard.packages.${pkgs.stdenv.hostPlatform.system}.default ]
+        ++ [ pkgs.home-manager ]
+        ++ [ emacs-vterm-module ];
+
+      programs.home-manager.enable = true;
+
+      # Firefox profile config (package installed + policies set in desktop.nix)
+      programs.firefox = {
+        enable = true;
+        package = null;  # don't install a second copy; system Firefox from desktop.nix
+
+        profiles.default = {
+          isDefault = true;
+
+          bookmarks = {
+            force = true;
+            settings = [
+              {
+                name = "d.rymcg.tech";
+                url = "https://github.com/EnigmaCurry/d.rymcg.tech/";
+              }
+              {
+                name = "blog.rymcg.tech";
+                url = "https://blog.rymcg.tech/";
+              }
+              {
+                name = "book.rymcg.tech";
+                url = "https://book.rymcg.tech/";
+              }
+              {
+                name = "nixos-vm-template";
+                url = "https://github.com/EnigmaCurry/nixos-vm-template";
+              }
+              {
+                name = "sway-home";
+                url = "https://github.com/EnigmaCurry/sway-home/";
+              }
+            ];
+          };
+
+          extensions.packages = with firefox-addons.packages.${pkgs.stdenv.hostPlatform.system}; [
+            ublock-origin
+            darkreader
+            vimium
+            multi-account-containers
+            temporary-containers
+          ];
+
+          # Search: DuckDuckGo only, hide all corporate engines
+          search = {
+            force = true;
+            default = "ddg";
+            privateDefault = "ddg";
+            order = [ "ddg" ];
+            engines = {
+              "google".metaData.hidden = true;
+              "bing".metaData.hidden = true;
+              "amazondotcom-us".metaData.hidden = true;
+              "ebay".metaData.hidden = true;
+              "wikipedia".metaData.hidden = true;
+              "perplexity".metaData.hidden = true;
+              "ddg".metaData.alias = "@ddg";
+            };
+          };
+
+          settings = {
+            # === Dark mode ===
+            "layout.css.prefers-color-scheme.content-override" = 0;
+            "browser.theme.content-theme" = 0;
+            "browser.theme.toolbar-theme" = 0;
+            "ui.systemUsesDarkTheme" = 1;
+            "extensions.activeThemeID" = "firefox-compact-dark@mozilla.org";
+
+            # === Startup: restore previous session, blank new tab ===
+            "browser.startup.homepage" = "about:blank";
+            "browser.startup.page" = 3;
+            "browser.newtabpage.enabled" = false;
+            "browser.newtabpage.activity-stream.showSponsored" = false;
+            "browser.newtabpage.activity-stream.showSponsoredTopSites" = false;
+            "browser.newtabpage.activity-stream.feeds.topsites" = false;
+            "browser.newtabpage.activity-stream.feeds.section.topstories" = false;
+            "browser.newtabpage.activity-stream.feeds.section.highlights" = false;
+            "browser.newtabpage.activity-stream.feeds.snippets" = false;
+            "browser.newtabpage.activity-stream.default.sites" = "";
+
+            # === Disable telemetry ===
+            "toolkit.telemetry.enabled" = false;
+            "toolkit.telemetry.unified" = false;
+            "toolkit.telemetry.server" = "";
+            "toolkit.telemetry.archive.enabled" = false;
+            "toolkit.telemetry.newProfilePing.enabled" = false;
+            "toolkit.telemetry.shutdownPingSender.enabled" = false;
+            "toolkit.telemetry.updatePing.enabled" = false;
+            "toolkit.telemetry.bhrPing.enabled" = false;
+            "toolkit.telemetry.firstShutdownPing.enabled" = false;
+            "toolkit.telemetry.coverage.opt-out" = true;
+            "toolkit.coverage.opt-out" = true;
+            "toolkit.coverage.endpoint.base" = "";
+            "datareporting.healthreport.uploadEnabled" = false;
+            "datareporting.policy.dataSubmissionEnabled" = false;
+            "app.shield.optoutstudies.enabled" = false;
+            "app.normandy.enabled" = false;
+            "app.normandy.api_url" = "";
+            "browser.ping-centre.telemetry" = false;
+            "breakpad.reportURL" = "";
+            "browser.tabs.crashReporting.sendReport" = false;
+            "browser.crashReports.unsubmittedCheck.autoSubmit2" = false;
+
+            # === Disable Pocket and sponsored content ===
+            "extensions.pocket.enabled" = false;
+            "browser.urlbar.suggest.quicksuggest.sponsored" = false;
+            "browser.urlbar.suggest.quicksuggest.nonsponsored" = false;
+
+            # === Search suggestions ===
+            "browser.search.suggest.enabled" = false;
+            "browser.urlbar.suggest.searches" = false;
+            "browser.urlbar.suggest.engines" = false;
+
+            # === History: clear on restart, keep bookmarks ===
+            "privacy.sanitize.sanitizeOnShutdown" = true;
+            "privacy.clearOnShutdown_v2.historyFormDataAndDownloads" = true;
+            "privacy.clearOnShutdown_v2.cookiesAndStorage" = true;
+            "privacy.clearOnShutdown_v2.cache" = true;
+            "privacy.clearOnShutdown_v2.siteSettings" = false;
+            "places.history.enabled" = false;
+
+            # === Privacy ===
+            "browser.contentblocking.category" = "strict";
+            "privacy.trackingprotection.enabled" = true;
+            "privacy.trackingprotection.socialtracking.enabled" = true;
+            "privacy.trackingprotection.cryptomining.enabled" = true;
+            "privacy.trackingprotection.fingerprinting.enabled" = true;
+            "extensions.formautofill.addresses.enabled" = false;
+            "extensions.formautofill.creditCards.enabled" = false;
+            "signon.rememberSignons" = false;
+
+            # === HTTPS-only mode ===
+            "dom.security.https_only_mode" = true;
+            "dom.security.https_only_mode_ever_enabled" = true;
+
+            # === Extensions: auto-enable without user approval ===
+            "extensions.autoDisableScopes" = 0;
+
+            # === UI cleanup ===
+            "browser.shell.checkDefaultBrowser" = false;
+            "browser.aboutConfig.showWarning" = false;
+            "browser.startup.homepage_override.mstone" = "ignore";
+            "media.autoplay.default" = 5;
+          };
+        };
+      };
+    };
+  };
+}

--- a/nix/workstation/installer/clone-to-device.sh
+++ b/nix/workstation/installer/clone-to-device.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+## Clone the booted workstation USB to another device
+## Usage: clone-to-device.sh [OPTIONS] /dev/sdX
+## Must be run as root on a booted workstation USB.
+## No build or network access required.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+DEVICE=""
+BASE_ONLY=""
+
+usage() {
+    echo "Usage: $0 [OPTIONS] /dev/sdX"
+    echo ""
+    echo "Clone this booted workstation USB to another device."
+    echo "Reuses the running system closure — no build or network needed."
+    echo "Must be run as root."
+    echo ""
+    echo "Options:"
+    echo "  --base-only    Install OS only, without archive data"
+    echo "  -h, --help     Show this help"
+    echo ""
+    echo "The root partition auto-expands to fill the device on first boot."
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --base-only)
+            BASE_ONLY=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+        *)
+            DEVICE="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$DEVICE" ]]; then
+    usage
+    exit 1
+fi
+
+if [[ ! -b "$DEVICE" ]]; then
+    echo "Error: $DEVICE is not a block device." >&2
+    exit 1
+fi
+
+if [[ $EUID -ne 0 ]]; then
+    echo "Error: This script must be run as root." >&2
+    exit 1
+fi
+
+# Resolve the running system closure
+SYSTEM_PATH=$(readlink -f /run/current-system)
+if [[ ! -d "$SYSTEM_PATH" ]]; then
+    echo "Error: /run/current-system does not resolve to a valid path." >&2
+    echo "This script must be run on a booted NixOS workstation USB." >&2
+    exit 1
+fi
+echo "System closure: $SYSTEM_PATH"
+
+# Find nixos-install
+NIXOS_INSTALL=$(command -v nixos-install 2>/dev/null || true)
+if [[ -z "$NIXOS_INSTALL" ]]; then
+    echo "Error: nixos-install not found in PATH." >&2
+    echo "Ensure nixos-install-tools is in systemPackages." >&2
+    exit 1
+fi
+echo "nixos-install: $NIXOS_INSTALL"
+
+# Discover the primary user from the booted USB
+SRC_USER=$(awk -F: '$3 >= 1000 && $3 < 65534 {print $1; exit}' /etc/passwd)
+echo "Source user: $SRC_USER"
+
+# Filesystem and encryption options
+ROOT_FSTYPE=$(script-wizard choose "Root filesystem" \
+    "ext4 — reliable default" \
+    "btrfs — compression (saves space), checksumming" \
+    --default "ext4 — reliable default")
+ROOT_FSTYPE="${ROOT_FSTYPE%% —*}"
+
+ENCRYPT_CHOICE=$(script-wizard choose "Encrypt root partition?" \
+    "No" \
+    "Yes (LUKS full disk encryption)" \
+    --default "No")
+ENCRYPT=""
+if [[ "$ENCRYPT_CHOICE" == "Yes"* ]]; then
+    ENCRYPT=1
+fi
+
+# Safety check
+echo ""
+echo "WARNING: This will ERASE ALL DATA on $DEVICE"
+echo ""
+lsblk "$DEVICE"
+echo ""
+echo "Filesystem: $ROOT_FSTYPE${ENCRYPT:+ (LUKS encrypted)}"
+echo "Account: $SRC_USER (password = username)"
+echo ""
+read -p "Type YES to continue: " confirm
+if [[ "$confirm" != "YES" ]]; then
+    echo "Aborted."
+    exit 1
+fi
+
+MOUNT=$(mktemp -d)
+cleanup() {
+    set +e
+    umount -R "$MOUNT" 2>/dev/null || true
+    [[ -n "${ENCRYPT:-}" ]] && cryptsetup close cryptroot 2>/dev/null || true
+    rmdir "$MOUNT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo ""
+echo "=== Partitioning $DEVICE ==="
+sgdisk --zap-all "$DEVICE"
+sgdisk -n 1:0:+1G -t 1:ef00 -c 1:ESP "$DEVICE"
+sgdisk -n 2:0:0 -t 2:8300 -c 2:nixos "$DEVICE"
+partprobe "$DEVICE" || true
+sleep 2
+
+# Determine partition names (handle nvme vs sd naming)
+if [[ "$DEVICE" =~ [0-9]$ ]]; then
+    ESP="${DEVICE}p1"
+    ROOT="${DEVICE}p2"
+else
+    ESP="${DEVICE}1"
+    ROOT="${DEVICE}2"
+fi
+
+echo "=== Formatting ==="
+mkfs.fat -F32 -n ESP "$ESP"
+
+if [[ -n "$ENCRYPT" ]]; then
+    echo "=== Setting up LUKS encryption ==="
+    echo "You will be prompted to create a passphrase."
+    cryptsetup -q luksFormat "$ROOT"
+    cryptsetup luksOpen "$ROOT" cryptroot
+    INNER_DEV="/dev/mapper/cryptroot"
+else
+    INNER_DEV="$ROOT"
+fi
+
+case "$ROOT_FSTYPE" in
+    btrfs) mkfs.btrfs -L nixos -f "$INNER_DEV" ;;
+    *)     mkfs.ext4 -L nixos -F "$INNER_DEV" ;;
+esac
+
+echo "=== Mounting ==="
+case "$ROOT_FSTYPE" in
+    btrfs) mount -o compress=zstd,noatime "$INNER_DEV" "$MOUNT" ;;
+    *)     mount "$INNER_DEV" "$MOUNT" ;;
+esac
+mkdir -p "$MOUNT/boot"
+mount -o umask=0077 "$ESP" "$MOUNT/boot"
+
+echo "=== Installing NixOS ==="
+"$NIXOS_INSTALL" --system "$SYSTEM_PATH" --root "$MOUNT" --no-root-password --no-channel-copy
+
+sed -i 's/^title .*/title NixOS Workstation/' "$MOUNT/boot/loader/entries/"*.conf
+
+echo ""
+echo "=== Archiving flake inputs for offline nixos-rebuild ==="
+# Allow nix/git to read the repo owned by $SRC_USER while running as root
+git config --global --add safe.directory "/home/$SRC_USER/git/vendor/enigmacurry/d.rymcg.tech"
+nix flake archive --to "local?root=$MOUNT" "/home/$SRC_USER/git/vendor/enigmacurry/d.rymcg.tech"
+mkdir -p "$MOUNT/root/.cache/nix"
+cp -a /root/.cache/nix/fetcher-cache-v*.sqlite* "$MOUNT/root/.cache/nix/" 2>/dev/null || true
+echo "Flake inputs archived"
+
+# Copy archive GC roots from the booted USB to the target
+if [[ -z "$BASE_ONLY" ]]; then
+    GCROOT_DIR="/nix/var/nix/gcroots"
+    TARGET_GCROOT="$MOUNT/nix/var/nix/gcroots"
+    mkdir -p "$TARGET_GCROOT"
+
+    echo ""
+    echo "=== Copying archive data ==="
+
+    copy_count=0
+    for root in "$GCROOT_DIR"/workstation-usb-*; do
+        [[ -L "$root" ]] || continue
+        name=$(basename "$root")
+        store_path=$(readlink "$root")
+        if [[ ! -e "$store_path" ]]; then
+            echo "  Skipping $name: store path does not exist"
+            continue
+        fi
+        size=$(du -shL "$store_path" | cut -f1)
+        echo "  Copying $name ($size)..."
+        target_store=$(nix store add --store "local?root=$MOUNT" --name "$name" "$store_path")
+        ln -sfn "$target_store" "$TARGET_GCROOT/$name"
+        echo "    -> $target_store"
+        copy_count=$((copy_count + 1))
+    done
+
+    if [[ $copy_count -eq 0 ]]; then
+        echo "  No archive GC roots found to copy."
+    else
+        echo "  Copied $copy_count archive items."
+    fi
+fi
+
+# Discover target username from the installed system
+TGT_USER=$(awk -F: '$3 >= 1000 && $3 < 65534 {print $1; exit}' "$MOUNT/etc/passwd")
+echo "Target user: $TGT_USER"
+
+echo ""
+echo "=== Running post-install chroot tasks ==="
+if [[ -x "$SCRIPT_DIR/post-install.sh" ]]; then
+    "$SCRIPT_DIR/post-install.sh" "$MOUNT" --chroot-only
+else
+    echo "Warning: post-install.sh not found, skipping chroot tasks."
+fi
+
+# Copy pre-built home directory resources from the booted USB to the clone.
+# These are normally downloaded by post-install.sh but that requires network.
+# Copying from the running system makes the clone fully air-gapped.
+echo ""
+echo "=== Copying home directory resources from booted USB ==="
+_src_home="/home/$SRC_USER"
+_dst_home="$MOUNT/home/$TGT_USER"
+_uid=$(grep "^${TGT_USER}:" "$MOUNT/etc/passwd" | cut -d: -f3)
+_gid=$(grep "^${TGT_USER}:" "$MOUNT/etc/passwd" | cut -d: -f4)
+
+_copy_home_resource() {
+    local rel_path="$1"
+    local description="$2"
+    local src="$_src_home/$rel_path"
+    local dst="$_dst_home/$rel_path"
+    if [[ -e "$src" ]]; then
+        local size dir
+        size=$(du -sh "$src" | cut -f1)
+        echo "  Copying $description ($size)..."
+        mkdir -p "$(dirname "$dst")"
+        # Fix ownership of intermediate dirs created by mkdir -p
+        dir="$(dirname "$dst")"
+        while [[ "$dir" != "$_dst_home" && "$dir" != "/" ]]; do
+            chown "$_uid:$_gid" "$dir"
+            dir="$(dirname "$dir")"
+        done
+        cp -a "$src" "$dst"
+        chown -R "$_uid:$_gid" "$dst"
+    else
+        echo "  Skipping $description: not found on source"
+    fi
+}
+
+_copy_home_resource ".rustup" "Rust toolchain"
+_copy_home_resource ".cargo" "Cargo config and cache"
+_copy_home_resource ".emacs.d/straight" "emacs packages (straight.el)"
+_copy_home_resource ".local/share/fonts" "nerd fonts"
+
+# Remove sensitive files that should not be cloned
+echo "  Scrubbing sensitive files from copy..."
+rm -f "$_dst_home/.cargo/credentials" "$_dst_home/.cargo/credentials.toml"
+rm -rf "$_dst_home/.rustup/tmp"
+
+# Copy custom.el if it's a regular file (not a home-manager symlink)
+if [[ -f "$_src_home/.emacs.d/custom.el" ]] && [[ ! -L "$_src_home/.emacs.d/custom.el" ]]; then
+    echo "  Copying emacs custom.el..."
+    mkdir -p "$_dst_home/.emacs.d"
+    cp -a "$_src_home/.emacs.d/custom.el" "$_dst_home/.emacs.d/custom.el"
+    chown "$_uid:$_gid" "$_dst_home/.emacs.d/custom.el"
+fi
+
+# Remove hardware-specific native modules from copied emacs packages
+find "$_dst_home/.emacs.d/straight" -name '*.so' -delete 2>/dev/null || true
+
+# Ensure .emacs.d directory itself is owned by the user (mkdir -p creates it as root)
+# so home-manager activation can create symlinks (emacs.org, init.el, etc.)
+if [[ -d "$_dst_home/.emacs.d" ]]; then
+    chown "$_uid:$_gid" "$_dst_home/.emacs.d"
+fi
+
+echo ""
+echo "=== Clone complete ==="
+echo "You can now boot from $DEVICE."
+echo "Account: $TGT_USER (password = username)"
+echo "The root partition will auto-expand on first boot."

--- a/nix/workstation/installer/install-to-device.sh
+++ b/nix/workstation/installer/install-to-device.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+## Install NixOS workstation directly to a USB device
+## Usage: install-to-device.sh [OPTIONS] /dev/sdX
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FLAKE_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BIN="${FLAKE_DIR}/_scripts"
+ROOT_DIR="$FLAKE_DIR"
+source "${BIN}/funcs.sh"
+source "${BIN}/workstation-build-lib.sh"
+
+DEVICE=""
+BASE_ONLY=""
+ARCHIVE_SOURCE="${FLAKE_DIR}/_archive"
+MANIFEST_FILE=""
+
+usage() {
+    echo "Usage: $0 [OPTIONS] /dev/sdX"
+    echo ""
+    echo "Install NixOS workstation directly to a USB device."
+    echo "Must be run as root."
+    echo ""
+    echo "Options:"
+    echo "  --base-only    Install OS only, without archive data"
+    echo "  -h, --help     Show this help"
+    echo ""
+    echo "Default password matches the username (change on first boot)."
+    echo "The root partition auto-expands to fill the USB on first boot."
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --base-only)
+            BASE_ONLY=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+        *)
+            DEVICE="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$DEVICE" ]]; then
+    usage
+    exit 1
+fi
+
+if [[ ! -b "$DEVICE" ]]; then
+    echo "Error: $DEVICE is not a block device." >&2
+    exit 1
+fi
+
+if [[ $EUID -ne 0 ]]; then
+    echo "Error: This script must be run as root." >&2
+    exit 1
+fi
+
+# Archive selection (before device confirmation so user can cancel early)
+if [[ -z "$BASE_ONLY" ]]; then
+    workstation_archive_preflight
+    workstation_archive_select
+fi
+
+workstation_configure_settings
+
+# Safety check
+echo "WARNING: This will ERASE ALL DATA on $DEVICE"
+echo ""
+lsblk "$DEVICE"
+echo ""
+read -p "Type YES to continue: " confirm
+if [[ "$confirm" != "YES" ]]; then
+    echo "Aborted."
+    exit 1
+fi
+
+MOUNT=$(mktemp -d)
+cleanup() {
+    set +e
+    umount -R "$MOUNT" 2>/dev/null || true
+    rmdir "$MOUNT" 2>/dev/null || true
+    if [[ -n "${MANIFEST_FILE:-}" ]] && [[ "$MANIFEST_FILE" == /tmp/* ]]; then
+        rm -f "$MANIFEST_FILE" 2>/dev/null
+    fi
+}
+trap cleanup EXIT
+
+echo ""
+workstation_create_bare_repos
+
+echo ""
+echo "=== Building NixOS system closure ==="
+SYSTEM_PATH=$(workstation_nix_build "nixosConfigurations.workstation.config.system.build.toplevel")
+echo "System closure: $SYSTEM_PATH"
+
+NIXOS_INSTALL=$(workstation_nix_build "nixosConfigurations.workstation.config.system.build.nixos-install")/bin/nixos-install
+if [[ ! -x "$NIXOS_INSTALL" ]]; then
+    echo "Error: nixos-install not found at $NIXOS_INSTALL" >&2
+    exit 1
+fi
+echo "nixos-install: $NIXOS_INSTALL"
+
+# Now that nix has read settings.nix, hide it from git status
+workstation_hide_settings
+
+echo "=== Partitioning $DEVICE ==="
+# Wipe existing partition table
+sgdisk --zap-all "$DEVICE"
+# Create ESP (1GB) and root partition (rest)
+sgdisk -n 1:0:+1G -t 1:ef00 -c 1:ESP "$DEVICE"
+sgdisk -n 2:0:0 -t 2:8300 -c 2:nixos "$DEVICE"
+partprobe "$DEVICE" || true
+sleep 2
+
+# Determine partition names (handle nvme vs sd naming)
+if [[ "$DEVICE" =~ [0-9]$ ]]; then
+    ESP="${DEVICE}p1"
+    ROOT="${DEVICE}p2"
+else
+    ESP="${DEVICE}1"
+    ROOT="${DEVICE}2"
+fi
+
+echo "=== Formatting ==="
+mkfs.fat -F32 -n ESP "$ESP"
+mkfs.btrfs -L nixos -f "$ROOT"
+
+echo "=== Mounting ==="
+mount -o compress=zstd,noatime "$ROOT" "$MOUNT"
+mkdir -p "$MOUNT/boot"
+mount -o umask=0077 "$ESP" "$MOUNT/boot"
+
+echo "=== Installing NixOS ==="
+"$NIXOS_INSTALL" --system "$SYSTEM_PATH" --root "$MOUNT" --no-root-password --no-channel-copy
+
+sed -i 's/^title .*/title d.rymcg.tech NixOS Installer/' "$MOUNT/boot/loader/entries/"*.conf
+
+echo ""
+echo "=== Archiving flake inputs for offline nixos-rebuild ==="
+nix flake archive --to "local?root=$MOUNT" "$ROOT_DIR"
+mkdir -p "$MOUNT/root/.cache/nix"
+cp -a /root/.cache/nix/fetcher-cache-v*.sqlite* "$MOUNT/root/.cache/nix/" 2>/dev/null || true
+echo "Flake inputs archived"
+
+echo "=== Running post-install ==="
+if [[ -x "$SCRIPT_DIR/post-install.sh" ]]; then
+    if [[ -z "$BASE_ONLY" ]]; then
+        "$SCRIPT_DIR/post-install.sh" "$MOUNT" "${MANIFEST_FILE:-}"
+    else
+        "$SCRIPT_DIR/post-install.sh" "$MOUNT" --chroot-only
+    fi
+else
+    echo "Note: Run workstation-usb-post-install $MOUNT to copy archive data."
+fi
+
+echo ""
+echo "=== Installation complete ==="
+echo "You can now boot from $DEVICE."
+echo "Default password matches the username (change on first boot)."
+echo "The root partition will auto-expand on first boot."

--- a/nix/workstation/installer/post-install.sh
+++ b/nix/workstation/installer/post-install.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+## Post-install: copy archive data and pre-download packages for air-gapped use
+## Usage: post-install.sh /mnt [MANIFEST|ARCHIVE_ROOT|--chroot-only|--archive-only]
+## Must be run after nixos-install, while the USB is still mounted.
+set -euo pipefail
+
+MOUNT="${1:-}"
+CHROOT_ONLY=""
+ARCHIVE_ONLY=""
+ARCHIVE_ROOT=""
+MANIFEST_MODE=""
+IMAGE_PROJECTS=""
+COMFYUI_FILES=""
+INCLUDE_ISOS=true
+INCLUDE_DOCKER_PACKAGES=true
+
+if [[ "${2:-}" == "--chroot-only" ]] || [[ "${3:-}" == "--chroot-only" ]]; then
+    CHROOT_ONLY=1
+elif [[ "${2:-}" == "--archive-only" ]] || [[ "${3:-}" == "--archive-only" ]]; then
+    ARCHIVE_ONLY=1
+fi
+
+if [[ -z "$CHROOT_ONLY" ]] && [[ -f "${2:-}" ]]; then
+    # Manifest file with archive selection
+    MANIFEST_MODE=1
+    source "${2}"
+elif [[ -z "$CHROOT_ONLY" ]] && [[ -z "$ARCHIVE_ONLY" ]] && [[ -n "${2:-}" ]]; then
+    # Legacy: archive root directory
+    ARCHIVE_ROOT="${2:-}"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FLAKE_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+ARCHIVE_ROOT="${ARCHIVE_ROOT:-$FLAKE_DIR/_archive}"
+
+if [[ -z "$MOUNT" ]]; then
+    echo "Usage: $0 /mnt [MANIFEST|ARCHIVE_ROOT|--chroot-only|--archive-only]"
+    echo "Copy archive data to a mounted NixOS workstation USB and"
+    echo "pre-download packages (emacs, Rust) for air-gapped use."
+    echo ""
+    echo "The USB root filesystem must be mounted at the given path."
+    echo ""
+    echo "Args:"
+    echo "  MANIFEST        Path to selection manifest (from workstation-usb-image)"
+    echo "  ARCHIVE_ROOT    Path to archive directory (default: _archive/)"
+    echo "  --chroot-only   Skip archive copying, only run chroot tasks"
+    echo "  --archive-only  Copy archive data only, skip chroot tasks (Rust, emacs)"
+    echo "                  Used with --from-base builds where chroot is already done"
+    exit 1
+fi
+
+if [[ ! -d "$MOUNT/nix/store" ]]; then
+    echo "Error: $MOUNT does not look like a NixOS root (no nix/store)." >&2
+    exit 1
+fi
+
+# Discover the normal user account (first UID >= 1000, < 65534)
+TARGET_USER=$(awk -F: '$3 >= 1000 && $3 < 65534 {print $1; exit}' "$MOUNT/etc/passwd")
+if [[ -z "$TARGET_USER" ]]; then
+    echo "Error: no normal user found in $MOUNT/etc/passwd" >&2
+    exit 1
+fi
+echo "Target user: $TARGET_USER"
+
+if [[ $EUID -ne 0 ]]; then
+    echo "Error: This script must be run as root." >&2
+    exit 1
+fi
+
+## Copy archive data to the USB's nix store (skipped with --chroot-only)
+if [[ -z "$CHROOT_ONLY" ]]; then
+    GCROOT_DIR="$MOUNT/nix/var/nix/gcroots"
+    mkdir -p "$GCROOT_DIR"
+
+    add_to_store() {
+        local source_path="$1"
+        local store_name="$2"
+        local gcroot_name="$3"
+
+        if [[ -L "$source_path" ]]; then
+            source_path=$(realpath "$source_path")
+        fi
+
+        if [[ ! -e "$source_path" ]]; then
+            echo "  Skipping $store_name: not found"
+            return
+        fi
+
+        if [[ -d "$source_path" ]] && [[ -z "$(ls -A "$source_path" 2>/dev/null)" ]]; then
+            echo "  Skipping $store_name: empty"
+            return
+        fi
+
+        local size
+        size=$(du -shL "$source_path" | cut -f1)
+        echo "  Adding $store_name ($size)..."
+        local store_path
+        store_path=$(nix store add --store "local?root=$MOUNT" --name "$gcroot_name" "$source_path")
+        ln -sfn "$store_path" "$GCROOT_DIR/$gcroot_name"
+        echo "    -> $store_path"
+    }
+
+    ARCHIVE_IMG_DIR="$ARCHIVE_ROOT/images/x86_64"
+
+    if [[ -n "$MANIFEST_MODE" ]]; then
+        # Manifest mode: add only selected categories
+        if [[ -n "$IMAGE_PROJECTS" ]] || [[ -n "$COMFYUI_FILES" ]]; then
+            echo "=== Adding Docker images to nix store ==="
+            for proj in $IMAGE_PROJECTS; do
+                add_to_store "$ARCHIVE_IMG_DIR/$proj" "$proj" "workstation-usb-image-$proj"
+            done
+            for f in $COMFYUI_FILES; do
+                add_to_store "$ARCHIVE_IMG_DIR/comfyui/$f" "comfyui/$f" "workstation-usb-comfyui-$f"
+            done
+            if [[ -f "$ARCHIVE_IMG_DIR/manifest.json" ]]; then
+                add_to_store "$ARCHIVE_IMG_DIR/manifest.json" "manifest.json" "workstation-usb-image-manifest"
+            fi
+            echo ""
+        else
+            echo "=== Docker images: none selected, skipping ==="
+            echo ""
+        fi
+
+        if $INCLUDE_ISOS; then
+            echo "=== Adding ISOs to nix store ==="
+            add_to_store "$ARCHIVE_ROOT/isos" "ISOs" "workstation-usb-isos"
+            echo ""
+        fi
+
+        if $INCLUDE_DOCKER_PACKAGES; then
+            echo "=== Adding Docker CE packages to nix store ==="
+            add_to_store "$ARCHIVE_ROOT/docker-packages" "Docker CE packages" "workstation-usb-docker-packages"
+            echo ""
+        fi
+    else
+        # Legacy mode: add entire archive directories
+        echo "=== Adding Docker image archive to nix store ==="
+        add_to_store "$ARCHIVE_IMG_DIR" "Docker image archive" "workstation-usb-archive"
+        echo ""
+        echo "=== Adding ISOs to nix store ==="
+        add_to_store "$ARCHIVE_ROOT/isos" "ISOs" "workstation-usb-isos"
+        echo ""
+        echo "=== Adding Docker CE packages to nix store ==="
+        add_to_store "$ARCHIVE_ROOT/docker-packages" "Docker CE packages" "workstation-usb-docker-packages"
+        echo ""
+    fi
+fi
+
+## Chroot setup and tasks (skipped in --archive-only mode)
+if [[ -n "$ARCHIVE_ONLY" ]]; then
+    echo "=== Post-install complete (archive-only mode) ==="
+    echo "Archive data has been copied to the USB's nix store."
+    echo "GC roots protect the data from garbage collection."
+    echo "Chroot tasks skipped (already baked into base image)."
+else
+    ## Set up chroot environment for pre-download tasks
+    # Set up DNS so straight.el can fetch packages
+    mkdir -p "$MOUNT/etc"
+    cp -L /etc/resolv.conf "$MOUNT/etc/resolv.conf" 2>/dev/null || true
+
+    # Bind-mount /dev, /proc, /sys for chroot
+    mount --bind /dev "$MOUNT/dev" 2>/dev/null || true
+    mount --bind /proc "$MOUNT/proc" 2>/dev/null || true
+    mount --bind /sys "$MOUNT/sys" 2>/dev/null || true
+
+    # Create per-user profile directory so home-manager's installPackages step
+    # can create the nix profile on first boot. Without this, home.packages
+    # (including fonts) silently fail to install.
+    _uid=$(grep "^${TARGET_USER}:" "$MOUNT/etc/passwd" | cut -d: -f3)
+    _gid=$(grep "^${TARGET_USER}:" "$MOUNT/etc/passwd" | cut -d: -f4)
+    mkdir -p "$MOUNT/nix/var/nix/profiles/per-user/$TARGET_USER"
+    chown "$_uid:$_gid" "$MOUNT/nix/var/nix/profiles/per-user/$TARGET_USER"
+
+    # Create home-manager gcroots directory so the activation script's
+    # nix-store --realise --add-root can succeed on first boot.
+    mkdir -p "$MOUNT/home/$TARGET_USER/.local/state/home-manager/gcroots"
+    chown -R "$_uid:$_gid" "$MOUNT/home/$TARGET_USER/.local"
+
+    # /run/current-system doesn't persist after nixos-install (/run is tmpfs at boot).
+    # Find the system closure and create the symlink so chroot commands work.
+    SYSTEM_STORE=$(find "$MOUNT/nix/store" -maxdepth 1 -name '*-nixos-system-*' -type d 2>/dev/null | head -1)
+    if [[ -n "$SYSTEM_STORE" ]]; then
+        SYSTEM_PATH="${SYSTEM_STORE#$MOUNT}"  # chroot-relative path
+        mkdir -p "$MOUNT/run"
+        ln -sfn "$SYSTEM_PATH" "$MOUNT/run/current-system"
+        echo "Set up /run/current-system -> $SYSTEM_PATH"
+    else
+        echo "Warning: NixOS system closure not found, chroot tasks may fail"
+    fi
+
+    # Home-manager activation only runs on first boot (as a systemd service),
+    # so ~/.emacs.d/ doesn't exist yet in the chroot after nixos-install.
+    # Create it from the home-manager generation so emacs pre-download works.
+    echo "=== Setting up home-manager symlinks ==="
+    USER_HOME="$MOUNT/home/$TARGET_USER"
+    HM_GEN=$(find "$MOUNT/nix/store" -maxdepth 1 -name '*-home-manager-generation' -type d 2>/dev/null | head -1)
+    if [[ -n "$HM_GEN" ]] && [[ -L "$HM_GEN/home-files" ]]; then
+        HM_HOME_FILES=$(readlink "$HM_GEN/home-files")
+        # HM_HOME_FILES is a chroot-relative absolute path (e.g. /nix/store/xxx-home-files)
+        # Prepend $MOUNT to access it from the host
+        if [[ -d "$MOUNT$HM_HOME_FILES/.emacs.d" ]]; then
+            mkdir -p "$USER_HOME/.emacs.d"
+            # Copy symlink structure (each file is a symlink to the nix store)
+            # into a writable directory so straight.el can create straight/ and custom.el
+            cp -a "$MOUNT$HM_HOME_FILES/.emacs.d/." "$USER_HOME/.emacs.d/"
+            # Resolve UID/GID from the target's passwd (chroot may not have /run set up)
+            _uid=$(grep "^${TARGET_USER}:" "$MOUNT/etc/passwd" | cut -d: -f3)
+            _gid=$(grep "^${TARGET_USER}:" "$MOUNT/etc/passwd" | cut -d: -f4)
+            chown -R "$_uid:$_gid" "$USER_HOME/.emacs.d"
+            # Nix store sources are read-only; make .emacs.d writable so emacs
+            # can create subdirectories (auto-save/, straight/, custom.el, etc.)
+            chmod -R u+w "$USER_HOME/.emacs.d"
+            # If custom.el is a symlink to the nix store (read-only), replace it
+            # with a writable copy so customize-save-customized can write to it
+            if [[ -L "$USER_HOME/.emacs.d/custom.el" ]]; then
+                _custom_target=$(readlink -f "$USER_HOME/.emacs.d/custom.el")
+                rm "$USER_HOME/.emacs.d/custom.el"
+                cp "$_custom_target" "$USER_HOME/.emacs.d/custom.el"
+                chown "$_uid:$_gid" "$USER_HOME/.emacs.d/custom.el"
+            fi
+            echo "Created ~/.emacs.d from home-manager generation"
+        else
+            echo "Warning: home-manager generation found but no .emacs.d directory"
+        fi
+    else
+        echo "Warning: no home-manager generation found, emacs pre-download will be skipped"
+    fi
+
+    # Pre-install Rust stable toolchain and emacs packages (requires network).
+    # Skip in --chroot-only mode: clone copies these from the booted USB instead,
+    # and --base-only installs are intentionally minimal.
+    if [[ -z "$CHROOT_ONLY" ]]; then
+        echo "=== Installing Rust stable toolchain ==="
+        chroot "$MOUNT" /run/current-system/sw/bin/su - "$TARGET_USER" -c '
+            rustup default stable
+            rustup component add rust-src rust-analyzer clippy rustfmt
+        ' || echo "Warning: Rust toolchain install failed (non-fatal)"
+
+        # Pre-download emacs packages for air-gapped use
+        # Load init.el with all machine labels enabled, triggering straight.el
+        # to download every package. Save the labels to custom.el for first boot.
+        echo "=== Pre-downloading emacs packages ==="
+        chroot "$MOUNT" /run/current-system/sw/bin/su - "$TARGET_USER" -c '
+            emacs --batch \
+                --eval "(progn
+                    (setq user-init-file (expand-file-name \"init.el\" user-emacs-directory))
+                    (setq custom-file (expand-file-name \"custom.el\" user-emacs-directory)))" \
+                -l ~/.emacs.d/init.el \
+                --eval "(progn
+                    (my/load-modules (my/machine-labels-available))
+                    (customize-set-variable (quote my/machine-labels) (my/machine-labels-available))
+                    (customize-save-customized)
+                    (message \"Emacs packages downloaded and all machine labels enabled.\"))" \
+                2>&1
+        ' || echo "Warning: emacs package pre-download failed (non-fatal)"
+    fi
+
+    # Clean up: remove home-manager-managed files from .emacs.d so that
+    # home-manager activation on first boot can create its symlinks cleanly.
+    # Keep only runtime-generated dirs (elpaca, straight, elpa, auto-save, etc.)
+    if [[ -d "$USER_HOME/.emacs.d" ]] && [[ -n "${HM_HOME_FILES:-}" ]] && [[ -d "$MOUNT$HM_HOME_FILES/.emacs.d" ]]; then
+        echo "=== Cleaning up .emacs.d for home-manager activation ==="
+        # Remove each file/dir that home-manager would manage (exists in the generation)
+        while IFS= read -r -d '' entry; do
+            rel="${entry#$MOUNT$HM_HOME_FILES/.emacs.d/}"
+            target="$USER_HOME/.emacs.d/$rel"
+            if [[ -e "$target" ]] && [[ ! -d "$target" ]]; then
+                rm -f "$target"
+            fi
+        done < <(find "$MOUNT$HM_HOME_FILES/.emacs.d" -not -type d -print0)
+        # Remove empty directories left behind (but not dirs with runtime content)
+        find "$USER_HOME/.emacs.d" -type d -empty -delete 2>/dev/null || true
+        echo "Removed home-manager-managed files, kept runtime downloads"
+    fi
+
+    # Remove native .so modules from the chroot pre-download — they may be
+    # corrupt (the chroot build env differs from the real runtime).
+    # The Nix-compiled vterm-module.so is provided via user profile site-lisp.
+    # Do NOT delete .elc files — they are valid and straight.el needs them
+    # for its build state and dependency resolution.
+    find "$USER_HOME/.emacs.d/straight" -name '*.so' -delete 2>/dev/null || true
+
+    # Clean up chroot mounts (kill lingering processes first so /dev unmounts cleanly)
+    fuser -km "$MOUNT" 2>/dev/null || true
+    sleep 1
+    umount "$MOUNT/sys" 2>/dev/null || true
+    umount "$MOUNT/proc" 2>/dev/null || true
+    umount "$MOUNT/dev" 2>/dev/null || umount -l "$MOUNT/dev" 2>/dev/null || true
+    sync
+
+    echo "=== Post-install complete ==="
+    if [[ -z "$CHROOT_ONLY" ]]; then
+        echo "Archive data has been copied to the USB's nix store."
+        echo "GC roots protect the data from garbage collection."
+    fi
+    if [[ -z "$CHROOT_ONLY" ]]; then
+        echo "Chroot tasks (emacs packages, Rust toolchain) completed."
+    else
+        echo "Chroot tasks completed (downloads skipped in chroot-only mode)."
+    fi
+fi

--- a/nix/workstation/networking.nix
+++ b/nix/workstation/networking.nix
@@ -1,0 +1,14 @@
+# Networking configuration for the workstation
+{ config, lib, pkgs, hostName, ... }:
+
+{
+  networking.hostName = hostName;
+
+  # NetworkManager for easy WiFi/Ethernet management
+  networking.networkmanager.enable = true;
+
+  # Firewall
+  networking.firewall.enable = true;
+  networking.firewall.allowedTCPPorts = [ ];
+  networking.firewall.allowedUDPPorts = [ ];
+}

--- a/nix/workstation/repos.nix
+++ b/nix/workstation/repos.nix
@@ -1,0 +1,101 @@
+# Git repo symlinks via home-manager home.file
+# Creates read-only nix store symlinks so all repos are available offline.
+# When vendor-git-repos is overridden at build time with bare clones (full history),
+# those are used directly. Otherwise, synthetic single-commit bare repos are created as fallback.
+{ config, lib, pkgs, self, sway-home-src, swayHomeInputs, org-src, vendor-git-repos, hostName, userName, remotes, ... }:
+
+let
+  # Create a single-commit bare repo from a source tree (fallback when vendor-git-repos isn't overridden)
+  mkBareRepo = name: src: pkgs.runCommand "${name}-bare-repo" {
+    nativeBuildInputs = [ pkgs.git ];
+  } ''
+    export HOME=$TMPDIR
+    WORK=$(mktemp -d)
+    cp -r ${src}/. "$WORK/"
+    cd "$WORK"
+    git init -b master --quiet
+    git add .
+    git -c user.email="nix@localhost" -c user.name="Nix" commit -m "Bundled source" --quiet
+    git clone --bare "$WORK" "$out"
+  '';
+
+  # Detect whether vendor-git-repos contains real bare repos (overridden at build time)
+  hasBareRepos = builtins.pathExists "${vendor-git-repos}/d.rymcg.tech/HEAD";
+
+  # Get bare repo for a given name, falling back to synthetic bare repo from source
+  getBareRepo = name: src:
+    if hasBareRepos
+    then "${vendor-git-repos}/${name}"
+    else mkBareRepo name src;
+
+  # Map repo names to their flake input sources
+  repoSources = {
+    "d.rymcg.tech" = self;
+    "sway-home" = sway-home-src;
+    "emacs" = swayHomeInputs.emacs_enigmacurry;
+    "blog.rymcg.tech" = swayHomeInputs.blog-rymcg-tech;
+    "org" = org-src;
+  };
+
+  bareRepos = lib.mapAttrs (name: src: getBareRepo name src) repoSources;
+
+  repoNames = lib.attrNames remotes;
+
+  # Generate home.file entries for vendor-nix symlinks
+  vendorNixFiles = lib.listToAttrs (map (name: {
+    name = "git/vendor-nix/enigmacurry/${name}";
+    value = { source = bareRepos.${name}; };
+  }) repoNames);
+
+  # Generate the clone script from remotes
+  cloneSnippet = name: url: ''
+    dest="$base/${name}"
+    if [ ! -d "$dest/.git" ]; then
+      echo "Cloning ${name} from nix store..."
+      git -c safe.directory='*' clone ${bareRepos.${name}} "$dest"
+      git -C "$dest" remote set-url origin ${url}
+  '' + lib.optionalString (name == "d.rymcg.tech") ''
+      # Ensure settings.nix reflects the baked-in configuration
+      sed -i 's/hostName = ".*"/hostName = "${hostName}"/' "$dest/nix/workstation/settings.nix"
+      sed -i 's/userName = ".*"/userName = "${userName}"/' "$dest/nix/workstation/settings.nix"
+      git -C "$dest" update-index --skip-worktree nix/workstation/settings.nix
+  '' + ''
+      echo "${name}: cloned and remote set"
+    else
+      echo "${name}: already exists, skipping"
+    fi
+  '';
+
+  cloneScript = lib.concatStringsSep "\n" (lib.mapAttrsToList cloneSnippet remotes);
+
+in
+{
+  home-manager.users.${userName} = { ... }: {
+    home.file = vendorNixFiles;
+
+    home.sessionPath = [
+      "/home/${userName}/git/vendor/enigmacurry/d.rymcg.tech/_scripts/user"
+    ];
+  };
+
+  # Clone writable repos from the nix store on first boot
+  systemd.services.workstation-clone-repos = {
+    description = "Clone writable git repos from nix store to ~/git/vendor/";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "local-fs.target" ];
+    path = [ pkgs.git ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      User = userName;
+      Group = "users";
+    };
+    script = ''
+      base="/home/${userName}/git/vendor/enigmacurry"
+      mkdir -p "$base"
+
+    '' + cloneScript;
+  };
+
+  # nixos-vm-template is already handled by sway-home.homeModules.nixos-vm-template
+}

--- a/nix/workstation/settings.nix
+++ b/nix/workstation/settings.nix
@@ -1,0 +1,14 @@
+# Workstation settings — edit this file to customize your system.
+# After editing, rebuild with: sudo nixos-rebuild switch
+{
+  hostName = "workstation";
+  userName = "user";
+  sudoUser = true;
+  remotes = {
+    "d.rymcg.tech" = "https://github.com/EnigmaCurry/d.rymcg.tech.git";
+    "sway-home" = "https://github.com/EnigmaCurry/sway-home.git";
+    "emacs" = "https://github.com/EnigmaCurry/emacs.git";
+    "blog.rymcg.tech" = "https://github.com/EnigmaCurry/blog.rymcg.tech.git";
+    "org" = "https://github.com/EnigmaCurry/org.git";
+  };
+}

--- a/nix/workstation/users.nix
+++ b/nix/workstation/users.nix
@@ -1,0 +1,18 @@
+# User account for the workstation
+{ config, lib, pkgs, userName, sudoUser, ... }:
+
+{
+  users.users.${userName} = {
+    isNormalUser = true;
+    description = userName;
+    extraGroups = lib.optionals sudoUser [ "wheel" ]
+      ++ [ "video" "audio" "input" "networkmanager" ];
+    initialPassword = userName;
+  };
+
+  # Allow wheel group to sudo
+  security.sudo.wheelNeedsPassword = true;
+
+  # Default shell
+  users.defaultUserShell = pkgs.bash;
+}

--- a/nix/workstation/workstation-packages.nix
+++ b/nix/workstation/workstation-packages.nix
@@ -1,0 +1,149 @@
+# All packages required for d.rymcg.tech operation + development tools
+{ config, lib, pkgs, self, ... }:
+
+let
+  # Build script-wizard binary matching .tools.lock.json for air-gapped use.
+  # install_script-wizard checks the nix store before downloading.
+  toolsLock = builtins.fromJSON (builtins.readFile "${self}/.tools.lock.json");
+  scriptWizardLock = toolsLock.dependencies.script-wizard;
+  scriptWizardVersion = scriptWizardLock.version;
+  script-wizard-locked = pkgs.fetchurl {
+    url = "https://github.com/EnigmaCurry/script-wizard/releases/download/v${scriptWizardVersion}/script-wizard-Linux-x86_64.tar.gz";
+    sha256 = scriptWizardLock.sha256;
+  };
+  script-wizard-bin = pkgs.runCommand "script-wizard-${scriptWizardVersion}" {} ''
+    mkdir -p $out/bin
+    tar xzf ${script-wizard-locked} -C $out/bin
+  '';
+in
+{
+  environment.systemPackages = with pkgs; [
+    # === d.rymcg.tech REQUIRED_COMMANDS (agent_readiness.py:359-362) ===
+    bashInteractive   # bash
+    gnumake           # make
+    git               # git
+    openssl           # openssl
+    apacheHttpd       # htpasswd
+    xdg-utils         # xdg-open
+    jq                # jq
+    sshfs             # sshfs
+    wireguard-tools   # wg
+    curl              # curl
+    inotify-tools     # inotifywait
+    w3m               # w3m
+    keychain          # keychain
+    ipcalc            # ipcalc
+    uv                # uv (Python package manager)
+    # docker is provided by virtualisation.docker.enable
+
+    # === Development tools ===
+    neovim
+    tmux
+    ripgrep
+    fd
+    tree
+    gettext
+    asciinema
+    imagemagick
+    wget
+    pkg-config
+    cmake
+    gnupatch
+    libvterm-neovim   # C library for emacs-vterm native module
+
+    # === Additional development tools ===
+    just
+    htop
+    file
+    unzip
+    zip
+    p7zip
+
+    # === Network diagnostics ===
+    nmap
+    netcat
+    dnsutils          # dig, nslookup
+    traceroute
+    tcpdump
+    ethtool
+    iperf3
+    whois
+    mtr               # traceroute + ping combined
+    socat
+    step-cli          # step-ca CLI for ACME / PKI
+    step-ca           # private ACME CA server
+    rclone            # cloud/remote file sync
+
+    # === Crypto / security ===
+    cryptsetup
+    gnupg
+    age
+    pass
+    pinentry-curses
+
+    # === Workstation/USB-specific tools ===
+    parted
+    gptfdisk
+    dosfstools
+    pv
+    rsync
+    ddrescue
+    cloud-utils       # growpart
+    e2fsprogs         # resize2fs
+    btrfs-progs       # mkfs.btrfs, btrfs filesystem resize
+    usbutils          # lsusb
+    pciutils          # lspci
+    smartmontools     # smartctl (disk health)
+    testdisk          # partition/file recovery
+    ntfs3g            # mount Windows drives
+    minicom           # serial console
+    picocom           # lightweight serial console
+    ipmitool          # server BMC management
+
+    # === Desktop (sway ecosystem) ===
+    # Firefox is configured via home-manager in home-manager.nix (with extensions)
+    networkmanagerapplet  # nm-applet tray icon for sway
+    kanshi                # auto display management
+    mako                  # desktop notifications
+    lxsession             # polkit agent (auth prompts for virt-manager, etc.)
+    grim                  # screenshot tool
+    slurp                 # screen region selector (pairs with grim)
+    wl-clipboard          # wl-copy/wl-paste
+    swaylock              # screen locker
+    swayidle              # idle management
+    pavucontrol           # PipeWire volume control GUI
+    brightnessctl         # laptop backlight control
+    dex                   # autostart .desktop files
+    blueman               # Bluetooth tray manager
+    # Thunar file manager is configured in desktop.nix
+    imv                   # Wayland image viewer
+    zathura               # PDF viewer
+    mpv                   # media player
+    wev                   # Wayland event viewer (debug input)
+
+    # === Python ===
+    python3
+    python3Packages.pip
+    python3Packages.virtualenv
+
+    # === Rust (rustup is in sway-home, these are build deps) ===
+    rustup
+    gcc
+    clang
+    llvmPackages.bintools
+
+    # === Virtualization ===
+    virt-manager
+    qemu_kvm
+    OVMF              # UEFI firmware for VMs
+    swtpm             # TPM emulator
+
+    # === Nix tools ===
+    nix-output-monitor
+    # nixos-rebuild is replaced by the flake-aware wrapper in first-boot.nix
+    nixos-install-tools   # nixos-install for workstation-usb-clone
+
+    # === d.rymcg.tech locked tools ===
+    script-wizard-bin  # exact version from .tools.lock.json for air-gapped install
+  ];
+}


### PR DESCRIPTION
## Summary
- Adds a complete NixOS-based workstation system for building bootable USB disks
- Bundles all tools and Docker images for fully offline d.rymcg.tech deployment (air-gapped environments)
- Declarative NixOS configuration via flake with modules for Sway desktop, Docker, home-manager, networking, and hardware
- Includes image builder, installer scripts, ISO/Docker package downloaders, and QEMU test VM support

## Files (27 new, 4434 lines)
- `flake.nix` + `flake.lock` — Nix flake definition
- `nix/workstation/*.nix` — NixOS modules (boot, desktop, docker, hardware, home-manager, etc.)
- `nix/workstation/installer/` — clone-to-device, install-to-device, post-install scripts
- `_scripts/workstation-*` — image builder, USB clone, ISO/package downloaders, test VM
- `WORKSTATION_USB.md` — documentation

Depends on #628

Closes #638

## Test plan
- [ ] `nix flake check` passes
- [ ] `workstation-usb-image` builds a bootable image in QEMU
- [ ] `workstation-usb-test-vm` boots successfully
- [ ] Air-gapped install completes with bundled Docker images