### PR TITLE
Registry: external volume support and entrypoint fixes

### DIFF
--- a/registry/.env-dist
+++ b/registry/.env-dist
@@ -17,6 +17,9 @@ REGISTRY_HTTP_SECRET=
 ## Storage backend: "docker" or "s3"
 REGISTRY_STORAGE_BACKEND=docker
 
+## External Docker volume name for registry data (blank to use a compose-managed volume):
+REGISTRY_EXTERNAL_VOLUME=
+
 ## S3 Bucket settings (ignored if REGISTRY_STORAGE_BACKEND=docker)
 REGISTRY_STORAGE_S3_ENDPOINT=https://s3.example.com
 REGISTRY_STORAGE_S3_REGION=

--- a/registry/Makefile
+++ b/registry/Makefile
@@ -14,7 +14,16 @@ config-hook:
 	@${BIN}/reconfigure_password ${ENV_FILE} REGISTRY_HTTP_SECRET
 	@echo
 	@echo "By default, Registry storage uses a Docker volume. Optionally, you can use an S3 bucket."
+	@echo "(NOTE: S3 storage is EXPERIMENTAL and may not work with all S3 providers.)"
 	@${BIN}/reconfigure_choose ${ENV_FILE} REGISTRY_STORAGE_BACKEND "Choose the storage backend:" "docker" "s3"
+	@[[ $$(${BIN}/dotenv -f ${ENV_FILE} get REGISTRY_STORAGE_BACKEND) == "docker" ]] && ( \
+		VOLUME_TYPE=$$(${BIN}/script-wizard choose "Choose the Docker volume type:" "compose" "external"); \
+		if [[ "$${VOLUME_TYPE}" == "external" ]]; then \
+			${BIN}/reconfigure_ask ${ENV_FILE} REGISTRY_EXTERNAL_VOLUME "Enter the external Docker volume name"; \
+		else \
+			${BIN}/reconfigure ${ENV_FILE} REGISTRY_EXTERNAL_VOLUME=; \
+		fi \
+	) || true
 	@[[ $$(${BIN}/dotenv -f ${ENV_FILE} get REGISTRY_STORAGE_BACKEND) == "s3" ]] && \
 		${BIN}/reconfigure_ask ${ENV_FILE} REGISTRY_STORAGE_S3_ENDPOINT "Enter the S3 endpoint URL" && \
 		${BIN}/reconfigure_ask ${ENV_FILE} REGISTRY_STORAGE_S3_REGION "Enter the S3 region (use 'auto' for Cloudflare R2)" && \
@@ -51,7 +60,7 @@ override-hook:
 ####                         # (this hardcodes the string into docker-compose.override.yaml)
 ####   name=@VARIABLE_NAME   # sets the template 'name' field to the literal string '${VARIABLE_NAME}'
 ####                         # (used for regular docker-compose expansion of env vars by name.)
-	@${BIN}/docker_compose_override ${ENV_FILE} project=:registry instance=@REGISTRY_INSTANCE traefik_host=@REGISTRY_TRAEFIK_HOST http_auth=REGISTRY_HTTP_AUTH http_auth_var=@REGISTRY_HTTP_AUTH ip_sourcerange=@REGISTRY_IP_SOURCERANGE enable_mtls_auth=REGISTRY_MTLS_AUTH mtls_authorized_certs=REGISTRY_MTLS_AUTHORIZED_CERTS storage_backend=REGISTRY_STORAGE_BACKEND public=REGISTRY_PUBLIC pull_http_auth=REGISTRY_PULL_HTTP_AUTH pull_http_auth_var=@REGISTRY_PULL_HTTP_AUTH pull_mtls_auth=REGISTRY_PULL_MTLS_AUTH pull_mtls_authorized_certs=REGISTRY_PULL_MTLS_AUTHORIZED_CERTS
+	@${BIN}/docker_compose_override ${ENV_FILE} project=:registry instance=@REGISTRY_INSTANCE traefik_host=@REGISTRY_TRAEFIK_HOST http_auth=REGISTRY_HTTP_AUTH http_auth_var=@REGISTRY_HTTP_AUTH ip_sourcerange=@REGISTRY_IP_SOURCERANGE enable_mtls_auth=REGISTRY_MTLS_AUTH mtls_authorized_certs=REGISTRY_MTLS_AUTHORIZED_CERTS storage_backend=REGISTRY_STORAGE_BACKEND public=REGISTRY_PUBLIC pull_http_auth=REGISTRY_PULL_HTTP_AUTH pull_http_auth_var=@REGISTRY_PULL_HTTP_AUTH pull_mtls_auth=REGISTRY_PULL_MTLS_AUTH pull_mtls_authorized_certs=REGISTRY_PULL_MTLS_AUTHORIZED_CERTS external_volume=REGISTRY_EXTERNAL_VOLUME
 
 .PHONY: shell
 shell:
@@ -226,4 +235,4 @@ install-hook:
 
 .PHONY: install-hook-pre
 install-hook-pre:
-	@echo
+	@make --no-print-directory docker-compose-lifecycle-cmd EXTRA_ARGS="rm -sf config"

--- a/registry/README.md
+++ b/registry/README.md
@@ -57,7 +57,10 @@ Url encoded: https://ryan:hunter2@example.com/...
 
 By default, the registry stores images in a Docker volume. You can
 optionally use an S3-compatible bucket (e.g., AWS S3, Cloudflare R2,
-MinIO) for storage:
+MinIO) for storage.
+
+**NOTE: S3 storage is EXPERIMENTAL and may not work reliably with all
+S3-compatible providers.**
 
 ```stdout
 By default, Registry storage uses a Docker volume. Optionally, you can use an S3 bucket.

--- a/registry/config/entrypoint.sh
+++ b/registry/config/entrypoint.sh
@@ -8,6 +8,7 @@ CFG_DIR=/etc/docker/registry
 CFG_PATH=${CFG_DIR}/config.yml
 
 [ -d "$CFG_DIR" ] || mkdir -p "$CFG_DIR" || die "cannot mkdir $CFG_DIR"
+chmod 0755 "$CFG_DIR" 2>/dev/null || true
 [ -w "$CFG_DIR" ] || die "config dir not writable: $CFG_DIR (is the volume mounted?)"
 
 STORAGE_BACKEND=${REGISTRY_STORAGE_BACKEND:-docker}
@@ -28,13 +29,17 @@ elif [ "$STORAGE_BACKEND" = "s3" ]; then
     accesskey: ${REGISTRY_STORAGE_S3_ACCESSKEY}
     secretkey: ${REGISTRY_STORAGE_S3_SECRETKEY}
     secure: true
-    v4auth: true"
+    v4auth: true
+    chunksize: 33554432"
 else
     die "unknown storage backend: $STORAGE_BACKEND"
 fi
 
-TMP=$(mktemp)
-cat > "$TMP" <<EOF
+if [ -f "$CFG_PATH" ]; then
+    rm "$CFG_PATH" 2>/dev/null || chmod 0644 "$CFG_PATH"
+fi
+
+cat > "$CFG_PATH" <<EOF
 version: 0.1
 log:
   fields:
@@ -56,6 +61,5 @@ health:
     threshold: 3
 EOF
 
-mv "$TMP" "$CFG_PATH"
 chmod 0444 "$CFG_PATH"
 log "wrote $CFG_PATH"

--- a/registry/docker-compose.instance.yaml
+++ b/registry/docker-compose.instance.yaml
@@ -19,6 +19,8 @@
 
 #! ### Custom project vars
 #@ s3_storage = data.values.storage_backend == "s3"
+#@ external_volume = data.values.external_volume.strip()
+#@ use_external_volume = len(external_volume) > 0
 #@ enable_public = data.values.public == "true"
 #@ enable_pull_http_auth = len(data.values.pull_http_auth.strip()) > 0
 #@ pull_http_auth = data.values.pull_http_auth_var
@@ -34,7 +36,11 @@ services:
       - REGISTRY_HTTP_SECRET=${REGISTRY_HTTP_SECRET}
     #@ if not s3_storage:
     volumes:
+      #@ if use_external_volume:
+      - (@= external_volume @):/var/lib/registry
+      #@ else:
       - registry:/var/lib/registry
+      #@ end
     #@ end
     labels:
       - "backup-volume.stop-during-backup=true"
@@ -116,3 +122,10 @@ services:
 
       - "traefik.http.routers.(@= router_pull @).middlewares=(@= ','.join(pull_middlewares) @)"
       #@ end
+
+#@ if use_external_volume and not s3_storage:
+#@yaml/text-templated-strings
+volumes:
+  (@= external_volume @):
+    external: true
+#@ end

--- a/registry/docker-compose.yaml
+++ b/registry/docker-compose.yaml
@@ -24,6 +24,11 @@ services:
         condition: service_completed_successfully
     cap_drop:
       - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - SETUID
+      - SETGID
     security_opt:
       - no-new-privileges:true
     sysctls:


### PR DESCRIPTION
## Summary
- Adds `REGISTRY_EXTERNAL_VOLUME` option to use a pre-existing Docker volume for registry data
- Config wizard prompts for compose-managed vs external volume when using Docker storage backend
- Fixes entrypoint permission handling (chmod config dir, handle existing config on restart, direct file write)
- Adds required capabilities (CHOWN, DAC_OVERRIDE, SETUID, SETGID) for entrypoint operations
- Removes stale config container on pre-install
- Adds S3 experimental warning to README and config wizard
- Adds S3 chunksize setting (33MB) for better upload reliability

Depends on #628

Closes #642

## Test plan
- [ ] `make config` with compose volume (default) works as before
- [ ] `make config` with external volume prompts correctly and generates valid override yaml
- [ ] `make install` succeeds with external volume
- [ ] Registry restarts cleanly (entrypoint handles existing config)
- [ ] S3 backend still works with chunksize addition