### PR TITLE
Fix ForwardAuth warnings for trustForwardHeader and maxResponseBodySize

### DIFF
--- a/traefik-forward-auth/docker-compose.yaml
+++ b/traefik-forward-auth/docker-compose.yaml
@@ -37,6 +37,8 @@ services:
       - "traefik.http.services.traefik-forward-auth.loadbalancer.server.port=4181"
       - "traefik.http.middlewares.traefik-forward-auth.forwardAuth.address=http://127.0.0.1:4181"
       - "traefik.http.middlewares.traefik-forward-auth.forwardAuth.authResponseHeaders=X-Forwarded-User"
+      - "traefik.http.middlewares.traefik-forward-auth.forwardAuth.trustForwardHeader=true"
+      - "traefik.http.middlewares.traefik-forward-auth.forwardAuth.maxResponseBodySize=1048576"
 
       - "traefik.http.routers.traefik-forward-auth.rule=Host(`${TRAEFIK_FORWARD_AUTH_HOST}`)"
       - "traefik.http.routers.traefik-forward-auth.entrypoints=websecure"


### PR DESCRIPTION
## Summary
- Add `trustForwardHeader=true` and `maxResponseBodySize=1048576` to the ForwardAuth middleware labels
- Fixes repeated Traefik v3.6 warnings about unconfigured ForwardAuth options

Fixes #648