### PR TITLE
Add ability to pin llama-cpp version

### DIFF
--- a/llama-cpp/.env-dist
+++ b/llama-cpp/.env-dist
@@ -1,4 +1,4 @@
-# The base docker image for llama.cpp (tag is constructed from LLAMA_IMAGE_VARIANT + profile suffix):
+# The base docker image for llama.cpp (tag is constructed from LLAMA_IMAGE_VARIANT + profile suffix, optionally followed by a release tag from LLAMA_IMAGE_TAG):
 # Available variants: server, full, light
 # GPU profiles append: -cuda, -rocm (e.g., server-cuda, full-rocm)
 # See https://github.com/ggml-org/llama.cpp/blob/master/docs/docker.md
@@ -9,6 +9,12 @@ LLAMA_IMAGE=ghcr.io/ggml-org/llama.cpp
 # full   - llama-server + model conversion tools + quantization tools
 # light  - llama-server + llama-cli (minimal)
 LLAMA_IMAGE_VARIANT=server
+
+# Optional: pin to a specific image tag (e.g., v0.1.2 or b10488).
+# If set, it is appended to the image tag (e.g., server-rocm-v0.1.2).
+# Leave blank to use the latest (rolling) image.
+# See https://github.com/ggml-org/llama.cpp/releases
+LLAMA_IMAGE_TAG=
 
 # The domain name for the llama.cpp service:
 LLAMA_TRAEFIK_HOST=llama.example.com

--- a/llama-cpp/.env-dist
+++ b/llama-cpp/.env-dist
@@ -1,4 +1,6 @@
-# The base docker image for llama.cpp (tag is constructed from LLAMA_IMAGE_VARIANT + profile suffix, optionally followed by a release tag from LLAMA_IMAGE_TAG):
+# The base docker image for llama.cpp (tag is constructed from
+# LLAMA_IMAGE_VARIANT + profile suffix, optionally followed by
+# a release tag from LLAMA_IMAGE_TAG):
 # Available variants: server, full, light
 # GPU profiles append: -cuda, -rocm (e.g., server-cuda, full-rocm)
 # See https://github.com/ggml-org/llama.cpp/blob/master/docs/docker.md

--- a/llama-cpp/Makefile
+++ b/llama-cpp/Makefile
@@ -23,6 +23,7 @@ config-hook:
 		${BIN}/reconfigure ${ENV_FILE} "LLAMA_HSA_OVERRIDE_GFX_VERSION="; \
 	fi
 	@${BIN}/reconfigure_choose ${ENV_FILE} LLAMA_IMAGE_VARIANT "Select the image variant:" server full light
+	@ALLOW_BLANK=1 ${BIN}/reconfigure_ask ${ENV_FILE} LLAMA_IMAGE_TAG "Enter a llama.cpp image tag to pin to (e.g., v0.1.2), or leave blank to use the latest image."
 	@echo ""
 	@ALLOW_BLANK=1 ${BIN}/reconfigure_ask ${ENV_FILE} LLAMA_MODELS_HOST_PATH "If you want to save models in a specific directory on the host, enter the path here, or leave blank to save models to the llama.cpp container's named Docker volume."
 	@echo

--- a/llama-cpp/README.md
+++ b/llama-cpp/README.md
@@ -13,14 +13,18 @@ make config
 
 This will ask you to enter the domain name to use, select the GPU
 profile (cpu/cuda/rocm), choose the image variant (server/full/light),
-and configure model storage. It automatically saves your responses
-into the configuration file `.env_{DOCKER_CONTEXT}_{INSTANCE}`.
+pin to an image tag (optional), and configure model storage. It
+automatically saves your responses into the configuration file
+`.env_{DOCKER_CONTEXT}_{INSTANCE}`.
 
 ### Image Variants
 
 - **server** - Only `llama-server` (smallest, recommended for API-only use)
 - **full** - `llama-server` + model conversion tools + quantization tools
 - **light** - `llama-server` + `llama-cli` (minimal)
+
+Set `LLAMA_IMAGE_TAG` to pin the image to a specific release (e.g.,
+`server-rocm-v0.1.2`); leave blank for the latest (rolling) image.
 
 ### Authentication and Authorization
 

--- a/llama-cpp/docker-compose.yaml
+++ b/llama-cpp/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   llama-cpu:
     profiles:
       - cpu
-    image: ${LLAMA_IMAGE}:${LLAMA_IMAGE_VARIANT}
+    image: ${LLAMA_IMAGE}:${LLAMA_IMAGE_VARIANT}${LLAMA_IMAGE_TAG:+-${LLAMA_IMAGE_TAG}}
     restart: unless-stopped
     cap_drop:
       - ALL
@@ -14,7 +14,7 @@ services:
   llama-cuda:
     profiles:
       - cuda
-    image: ${LLAMA_IMAGE}:${LLAMA_IMAGE_VARIANT}-cuda
+    image: ${LLAMA_IMAGE}:${LLAMA_IMAGE_VARIANT}-cuda${LLAMA_IMAGE_TAG:+-${LLAMA_IMAGE_TAG}}
     restart: unless-stopped
     cap_drop:
       - ALL
@@ -28,7 +28,7 @@ services:
   llama-rocm:
     profiles:
       - rocm
-    image: ${LLAMA_IMAGE}:${LLAMA_IMAGE_VARIANT}-rocm
+    image: ${LLAMA_IMAGE}:${LLAMA_IMAGE_VARIANT}-rocm${LLAMA_IMAGE_TAG:+-${LLAMA_IMAGE_TAG}}
     restart: unless-stopped
     devices:
       - /dev/kfd


### PR DESCRIPTION
Entering a value for `LLAMA_IMAGE_TAG` correctly constructs the image name, like:
So:
```
LLAMA_IMAGE=ghcr.io/ggml-org/llama.cpp
LLAMA_IMAGE_VARIANT=server
LLAMA_DOCKER_COMPOSE_PROFILES=rocm
LLAMA_IMAGE_TAG=v0.1.2
````
...would create an image of `ghcr.io/ggml-org/llama.cpp:server-rocm-v0.1.2` which is valid (well, at this time, v0.1.2 is pre-release so there is no image).

Leaving `LLAMA_IMAGE_TAG` blank also correct constructs the image name and uses the then-current release: e.g., `ghcr.io/ggml-org/llama.cpp:server-rocm`

Resolves #668 